### PR TITLE
sigpipe signal processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+.idea
+.vscode
 /categraf*
 *.log

--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func main() {
 
 func handleSignal(ag *agent.Agent) {
 	sc := make(chan os.Signal, 1)
-	signal.Notify(sc, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	signal.Notify(sc, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGPIPE)
 
 EXIT:
 	for {
@@ -66,6 +66,9 @@ EXIT:
 			break EXIT
 		case syscall.SIGHUP:
 			ag.Reload()
+		case syscall.SIGPIPE:
+			// https://pkg.go.dev/os/signal#hdr-SIGPIPE
+			// do nothing
 		default:
 			break EXIT
 		}


### PR DESCRIPTION
采用systemd托管的程序，默认会吧stdout stderr发给journald，journald重启或者crash时，程序写入到broken pipe
,内核会发送sigpipe信号。

如果程序没有处理sigpipe信号，fd为1、2写入broken pipe会导致程序退出。
即使配置了 restart=on-failure， systemd也不会重启程序，因为systemd默认的成功退出码中包含sigpipe

go关于sigpipe信号的说明https://pkg.go.dev/os/signal#hdr-SIGPIPE
> When a Go program writes to a broken pipe, the kernel will raise a SIGPIPE signal.
> 
> If the program has not called Notify to receive SIGPIPE signals, then the behavior depends on the file descriptor number. A write to a broken pipe on file descriptors 1 or 2 (standard output or standard error) will cause the program to exit with a SIGPIPE signal. A write to a broken pipe on some other file descriptor will take no action on the SIGPIPE signal, and the write will fail with an EPIPE error.
> 
> If the program has called Notify to receive SIGPIPE signals, the file descriptor number does not matter. The SIGPIPE signal will be delivered to the Notify channel, and the write will fail with an EPIPE error.

**未加信号处理**
![CleanShot 2022-05-12 at 11 41 46@2x](https://user-images.githubusercontent.com/12164762/167987915-50bfc4b1-b68a-447f-9dfb-38bbd6e2e8a0.png)
**加了信号处理**
程序存活，但是log写入失败，不再写入
![CleanShot 2022-05-12 at 11 55 00@2x](https://user-images.githubusercontent.com/12164762/167989177-42365573-cc42-4fd7-9759-94260da80aeb.png)
