### PR TITLE
input: docker should be init failed if the daemon not started

### DIFF
--- a/inputs/docker/client.go
+++ b/inputs/docker/client.go
@@ -20,6 +20,7 @@ type Client interface {
 	ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error)
 	ContainerStats(ctx context.Context, containerID string, stream bool) (types.ContainerStats, error)
 	ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error)
+	Ping(ctx context.Context) (types.Ping, error)
 	ServiceList(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error)
 	TaskList(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error)
 	NodeList(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error)
@@ -61,6 +62,9 @@ type SocketClient struct {
 
 func (c *SocketClient) Info(ctx context.Context) (types.Info, error) {
 	return c.client.Info(ctx)
+}
+func (c *SocketClient) Ping(ctx context.Context) (types.Ping, error) {
+	return c.client.Ping(ctx)
 }
 func (c *SocketClient) ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error) {
 	return c.client.ContainerList(ctx, options)


### PR DESCRIPTION
If the docker daemon not started, the docker input should not be started as well (like kubernetes input).

```
2022/06/15 18:07:34 docker.go:181: E! failed to gather docker info: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
2022/06/15 18:07:34 reader.go:141: >> count: 33
2022/06/15 18:07:34 reader.go:141: >> count: 14
2022/06/15 18:07:34 reader.go:141: >> count: 1
2022/06/15 18:07:34 reader.go:141: >> count: 5
2022/06/15 18:07:34 reader.go:141: >> count: 34
2022/06/15 18:07:34 reader.go:141: >> count: 11
2022/06/15 18:07:34 reader.go:141: >> count: 10
2022/06/15 18:07:34 reader.go:141: >> count: 13
2022/06/15 18:07:34 reader.go:141: >> count: 8
2022/06/15 18:07:34 reader.go:141: >> count: 11
2022/06/15 18:07:49 docker.go:181: E! failed to gather docker info: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
2022/06/15 18:07:49 reader.go:141: >> count: 33
2022/06/15 18:07:49 reader.go:141: >> count: 14
2022/06/15 18:07:49 reader.go:141: >> count: 11
2022/06/15 18:07:49 reader.go:141: >> count: 5
2022/06/15 18:07:49 reader.go:141: >> count: 1
2022/06/15 18:07:49 reader.go:141: >> count: 10
2022/06/15 18:07:49 reader.go:141: >> count: 11
2022/06/15 18:07:49 reader.go:141: >> count: 34
2022/06/15 18:07:49 reader.go:141: >> count: 13
2022/06/15 18:07:49 reader.go:141: >> count: 8
2022/06/15 18:07:49 reader.go:141: >> count: 11
2022/06/15 18:08:04 docker.go:181: E! failed to gather docker info: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
2022/06/15 18:08:04 reader.go:141: >> count: 14
2022/06/15 18:08:04 reader.go:141: >> count: 33
2022/06/15 18:08:04 reader.go:141: >> count: 11
2022/06/15 18:08:04 reader.go:141: >> count: 5
2022/06/15 18:08:04 reader.go:141: >> count: 1
2022/06/15 18:08:04 reader.go:141: >> count: 10
2022/06/15 18:08:04 reader.go:141: >> count: 34
2022/06/15 18:08:04 reader.go:141: >> count: 11
2022/06/15 18:08:04 reader.go:141: >> count: 11
2022/06/15 18:08:04 reader.go:141: >> count: 13
2022/06/15 18:08:04 reader.go:141: >> count: 8
2022/06/15 18:08:19 docker.go:181: E! failed to gather docker info: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
2022/06/15 18:08:19 reader.go:141: >> count: 11
```

and the docker input should init failed, but we got OK:

```
2022/06/15 18:07:19 agent.go:60: I! agent starting
2022/06/15 18:07:19 agent.go:129: I! input: cpu started
2022/06/15 18:07:19 agent.go:129: I! input: disk started
2022/06/15 18:07:19 agent.go:129: I! input: diskio started
2022/06/15 18:07:19 agent.go:129: I! input: docker started
2022/06/15 18:07:19 agent.go:129: I! input: kernel started
2022/06/15 18:07:19 agent.go:129: I! input: kernel_vmstat started
2022/06/15 18:07:19 agent.go:118: E! failed to init input: kubernetes error: open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory
2022/06/15 18:07:19 agent.go:129: I! input: linux_sysctl_fs started
2022/06/15 18:07:19 agent.go:129: I! input: mem started
2022/06/15 18:07:19 agent.go:129: I! input: net started
2022/06/15 18:07:19 agent.go:129: I! input: netstat started
2022/06/15 18:07:19 agent.go:129: I! input: nvidia_smi started
2022/06/15 18:07:19 agent.go:129: I! input: processes started
2022/06/15 18:07:19 agent.go:129: I! input: system started
```