### PR TITLE
fix: fix reload write chan error

### DIFF
--- a/agent/metrics_reader.go
+++ b/agent/metrics_reader.go
@@ -74,7 +74,7 @@ func (r *InputReader) gatherOnce() {
 	defer func() {
 		if r := recover(); r != nil {
 			if strings.Contains(fmt.Sprint(r), "closed channel") {
-				return
+				log.Println("E! gather metrics panic:", r)
 			} else {
 				log.Println("E! gather metrics panic:", r, string(runtimex.Stack(3)))
 			}


### PR DESCRIPTION
fix: fix reload write chan error

在 recover 中直接return 将使 recover 无法按预定逻辑运行，最终导致在reload的时候指标写入一个已经关闭的chan，从而导致程序异常退出。

问题如
#71 

Closes #71 

