### PR TITLE
fix mongo dashboard import error

### DIFF
--- a/inputs/mongodb/dashboard.json
+++ b/inputs/mongodb/dashboard.json
@@ -8,6 +8,7 @@
                 "definition": "label_values(mongodb_up,instance)"
             }
         ],
+        "version": "2.0.0",
         "panels": [
             {
                 "id": "dd7882d6-9502-4a76-845a-efdbcdb25466",


### PR DESCRIPTION
缺少version字段，导致导入后看板展示空