### PR TITLE
fix config collapse when instances were written in more than one file…

### DIFF
--- a/inputs/provider.go
+++ b/inputs/provider.go
@@ -61,7 +61,11 @@ type Provider interface {
 
 func NewProvider(c *config.ConfigType, reloadFunc func()) (Provider, error) {
 	log.Println("I! use input provider:", c.Global.Providers)
-
+	// 不添加provider配置 则默认使用local
+	// 兼容老版本
+	if len(c.Global.Providers) == 0 {
+		c.Global.Providers = append(c.Global.Providers, "local")
+	}
 	providers := make([]Provider, 0, len(c.Global.Providers))
 	for _, p := range c.Global.Providers {
 		name := strings.ToLower(p)
@@ -80,15 +84,7 @@ func NewProvider(c *config.ConfigType, reloadFunc func()) (Provider, error) {
 			providers = append(providers, provider)
 		}
 	}
-	// 不添加provider配置 则默认使用local
-	// 兼容老版本
-	if len(providers) == 0 {
-		provider, err := newLocalProvider(c)
-		if err != nil {
-			return nil, err
-		}
-		providers = append(providers, provider)
-	}
+
 	return &ProviderManager{
 		providers: providers,
 	}, nil

--- a/inputs/provider.go
+++ b/inputs/provider.go
@@ -80,6 +80,15 @@ func NewProvider(c *config.ConfigType, reloadFunc func()) (Provider, error) {
 			providers = append(providers, provider)
 		}
 	}
+	// 不添加provider配置 则默认使用local
+	// 兼容老版本
+	if len(providers) == 0 {
+		provider, err := newLocalProvider(c)
+		if err != nil {
+			return nil, err
+		}
+		providers = append(providers, provider)
+	}
 	return &ProviderManager{
 		providers: providers,
 	}, nil
@@ -224,7 +233,7 @@ func (lp *LocalProvider) GetInputConfig(inputKey string) ([]cfg.ConfigWithFormat
 		return nil, fmt.Errorf("failed to list files under: %s : %v", lp.configDir, err)
 	}
 
-	cwf := make([]cfg.ConfigWithFormat, 0, 1)
+	cwf := make([]cfg.ConfigWithFormat, 0, len(files))
 	for _, f := range files {
 		c, err := file.ReadBytes(path.Join(lp.configDir, inputFilePrefix+inputKey, f))
 		if err != nil {

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -3,8 +3,7 @@ package cfg
 import (
 	"bytes"
 	"fmt"
-	"io"
-	"os"
+	"io/ioutil"
 	"path"
 	"strings"
 
@@ -35,15 +34,6 @@ func GuessFormat(fpath string) ConfigFormat {
 	return TomlFormat
 }
 
-func readFile(fname string) ([]byte, error) {
-	file, err := os.Open(fname)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-	return io.ReadAll(file)
-}
-
 func LoadConfigByDir(configDir string, configPtr interface{}) error {
 	var (
 		tBuf, yBuf, jBuf []byte
@@ -60,7 +50,7 @@ func LoadConfigByDir(configDir string, configPtr interface{}) error {
 	}
 
 	for _, fpath := range files {
-		buf, err := readFile(path.Join(configDir, fpath))
+		buf, err := ioutil.ReadFile(path.Join(configDir, fpath))
 		if err != nil {
 			return err
 		}

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -1,7 +1,10 @@
 package cfg
 
 import (
+	"bytes"
 	"fmt"
+	"io"
+	"os"
 	"path"
 	"strings"
 
@@ -32,7 +35,20 @@ func GuessFormat(fpath string) ConfigFormat {
 	return TomlFormat
 }
 
+func readFile(fname string) ([]byte, error) {
+	file, err := os.Open(fname)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return io.ReadAll(file)
+}
+
 func LoadConfigByDir(configDir string, configPtr interface{}) error {
+	var (
+		tBuf, yBuf, jBuf []byte
+	)
+
 	loaders := []multiconfig.Loader{
 		&multiconfig.TagLoader{},
 		&multiconfig.EnvironmentLoader{},
@@ -44,26 +60,41 @@ func LoadConfigByDir(configDir string, configPtr interface{}) error {
 	}
 
 	for _, fpath := range files {
-		if strings.HasSuffix(fpath, ".toml") {
-			loaders = append(loaders, &multiconfig.TOMLLoader{Path: path.Join(configDir, fpath)})
+		buf, err := readFile(path.Join(configDir, fpath))
+		if err != nil {
+			return err
 		}
-		if strings.HasSuffix(fpath, ".json") {
-			loaders = append(loaders, &multiconfig.JSONLoader{Path: path.Join(configDir, fpath)})
+		switch {
+		case strings.HasSuffix(fpath, "toml"):
+			tBuf = append(tBuf, buf...)
+		case strings.HasSuffix(fpath, "json"):
+			jBuf = append(jBuf, buf...)
+		case strings.HasSuffix(fpath, "yaml") || strings.HasSuffix(fpath, "yml"):
+			yBuf = append(yBuf, buf...)
 		}
-		if strings.HasSuffix(fpath, ".yaml") || strings.HasSuffix(fpath, ".yml") {
-			loaders = append(loaders, &multiconfig.YAMLLoader{Path: path.Join(configDir, fpath)})
-		}
+	}
+
+	if len(tBuf) != 0 {
+		loaders = append(loaders, &multiconfig.TOMLLoader{Reader: bytes.NewReader(tBuf)})
+	}
+	if len(yBuf) != 0 {
+		loaders = append(loaders, &multiconfig.YAMLLoader{Reader: bytes.NewReader(yBuf)})
+	}
+	if len(jBuf) != 0 {
+		loaders = append(loaders, &multiconfig.JSONLoader{Reader: bytes.NewReader(jBuf)})
 	}
 
 	m := multiconfig.DefaultLoader{
 		Loader:    multiconfig.MultiLoader(loaders...),
 		Validator: multiconfig.MultiValidator(&multiconfig.RequiredValidator{}),
 	}
-
 	return m.Load(configPtr)
 }
 
 func LoadConfigs(configs []ConfigWithFormat, configPtr interface{}) error {
+	var (
+		tBuf, yBuf, jBuf []byte
+	)
 	loaders := []multiconfig.Loader{
 		&multiconfig.TagLoader{},
 		&multiconfig.EnvironmentLoader{},
@@ -71,12 +102,22 @@ func LoadConfigs(configs []ConfigWithFormat, configPtr interface{}) error {
 	for _, c := range configs {
 		switch c.Format {
 		case TomlFormat:
-			loaders = append(loaders, &multiconfig.TOMLLoader{Reader: strings.NewReader(c.Config)})
+			tBuf = append(tBuf, []byte(c.Config)...)
 		case YamlFormat:
-			loaders = append(loaders, &multiconfig.YAMLLoader{Reader: strings.NewReader(c.Config)})
+			yBuf = append(yBuf, []byte(c.Config)...)
 		case JsonFormat:
-			loaders = append(loaders, &multiconfig.JSONLoader{Reader: strings.NewReader(c.Config)})
+			jBuf = append(jBuf, []byte(c.Config)...)
 		}
+	}
+
+	if len(tBuf) != 0 {
+		loaders = append(loaders, &multiconfig.TOMLLoader{Reader: bytes.NewReader(tBuf)})
+	}
+	if len(yBuf) != 0 {
+		loaders = append(loaders, &multiconfig.YAMLLoader{Reader: bytes.NewReader(yBuf)})
+	}
+	if len(jBuf) != 0 {
+		loaders = append(loaders, &multiconfig.JSONLoader{Reader: bytes.NewReader(jBuf)})
 	}
 
 	m := multiconfig.DefaultLoader{


### PR DESCRIPTION
1. 问题：当instances在两个不同的配置文件中，后一个会覆盖前一个配置。例如input.redis/{redis6378.toml, redis6379.toml}，最终监控的是6379的配置
2. 解决方法： 将配置文件读到同一个buffer中，然后给multiconfig解析
3. 非slice类型的配置重复，例如两个global配置，启动会报错, 提示global已被定义（原有的代码是后面的配置覆盖前面）



