### PR TITLE
在大盘显示时以延时为监控目标时，响应时间在目标ping不通时上传值为-1

### DIFF
--- a/inputs/ping/ping.go
+++ b/inputs/ping/ping.go
@@ -154,6 +154,9 @@ func (ins *Instance) gather(slist *types.SampleList, target string) {
 			log.Println("D! no packets received, target:", target)
 		}
 		fields["result_code"] = 1
+		fields["minimum_response_ms"] = float64(-1)
+		fields["average_response_ms"] = float64(-1)
+		fields["maximum_response_ms"] = float64(-1)
 		fields["percent_packet_loss"] = float64(100)
 		return
 	}


### PR DESCRIPTION
当ping不通时，把response时间设置为-1，当大屏显示为延时时可做为特定依据显示成不同颜色和文字，如果不上传数据则不会变化，在大屏显示时不是很友好