### PR TITLE
fix: oracle plugin bug fix

### DIFF
--- a/inputs/oracle/oracle_linux_amd64.go
+++ b/inputs/oracle/oracle_linux_amd64.go
@@ -68,6 +68,7 @@ func (o *Oracle) Drop() {
 func (o *Oracle) GetInstances() []inputs.Instance {
 	ret := make([]inputs.Instance, len(o.Instances))
 	for i := 0; i < len(o.Instances); i++ {
+		o.Instances[i].Metrics = append(o.Instances[i].Metrics, o.Metrics...)
 		ret[i] = o.Instances[i]
 	}
 	return ret
@@ -117,12 +118,6 @@ func (ins *Instance) Gather(slist *types.SampleList) {
 	}
 
 	waitMetrics := new(sync.WaitGroup)
-
-	for i := 0; i < len(ins.Metrics); i++ {
-		m := ins.Metrics[i]
-		waitMetrics.Add(1)
-		go ins.scrapeMetric(waitMetrics, slist, m, tags)
-	}
 
 	for i := 0; i < len(ins.Metrics); i++ {
 		m := ins.Metrics[i]


### PR DESCRIPTION
fix: oracle plugin bug fix

1、oracle插件实例的metric应该是通用metric加上私有配置的metric，之前版本在实例没有配置私有metric的情况下，没有读取公有metric配置
2、oracle指标重复拉取问题