### PR TITLE
kafka and mongodb add more metrics

### DIFF
--- a/inputs/kafka/exporter/exporter.go
+++ b/inputs/kafka/exporter/exporter.go
@@ -201,8 +201,10 @@ func New(logger log.Logger, opts Options, topicFilter, groupFilter string) (*Exp
 
 	if opts.UseZooKeeperLag {
 		zookeeperClient, err = kazoo.NewKazoo(opts.UriZookeeper, nil)
-		level.Error(logger).Log("msg", "Error connecting to ZooKeeper", "err", err.Error())
-		return nil, err
+		if err != nil {
+			level.Error(logger).Log("msg", "Error connecting to ZooKeeper", "err", err.Error())
+			return nil, err
+		}
 	}
 
 	interval, err := time.ParseDuration(opts.MetadataRefreshInterval)

--- a/inputs/kafka/exporter/exporter.go
+++ b/inputs/kafka/exporter/exporter.go
@@ -769,7 +769,7 @@ func (e *Exporter) initializeMetrics() {
 
 	up := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "up"),
-		"Wether Kafka is up.",
+		"Whether Kafka is up.",
 		nil, labels,
 	)
 

--- a/inputs/kafka/exporter/exporter.go
+++ b/inputs/kafka/exporter/exporter.go
@@ -26,6 +26,7 @@ const (
 )
 
 type PromDesc struct {
+	up                                       *prometheus.Desc
 	clusterBrokers                           *prometheus.Desc
 	topicPartitions                          *prometheus.Desc
 	topicCurrentOffset                       *prometheus.Desc
@@ -200,6 +201,8 @@ func New(logger log.Logger, opts Options, topicFilter, groupFilter string) (*Exp
 
 	if opts.UseZooKeeperLag {
 		zookeeperClient, err = kazoo.NewKazoo(opts.UriZookeeper, nil)
+		level.Error(logger).Log("msg", "Error connecting to ZooKeeper", "err", err.Error())
+		return nil, err
 	}
 
 	interval, err := time.ParseDuration(opts.MetadataRefreshInterval)
@@ -259,6 +262,7 @@ func (e *Exporter) fetchOffsetVersion() int16 {
 // Describe describes all the metrics ever exported by the Kafka exporter. It
 // implements prometheus.Collector.
 func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
+	ch <- e.promDesc.up
 	ch <- e.promDesc.clusterBrokers
 	ch <- e.promDesc.topicCurrentOffset
 	ch <- e.promDesc.topicOldestOffset
@@ -345,11 +349,18 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) {
 		e.nextMetadataRefresh = now.Add(e.metadataRefreshInterval)
 	}
 
+	var value float64
+	defer func() {
+		ch <- prometheus.MustNewConstMetric(e.promDesc.up, prometheus.GaugeValue, value)
+	}()
+
 	topics, err := e.client.Topics()
 	if err != nil {
 		level.Error(e.logger).Log("msg", "Error getting topics: %s. Skipping metric generation", "err", err.Error())
 		return
 	}
+
+	value = 1
 
 	level.Info(e.logger).Log("msg", "Generating topic metrics")
 	for _, topic := range topics {
@@ -754,6 +765,12 @@ func (e *Exporter) initializeMetrics() {
 		}
 	}
 
+	up := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "up"),
+		"Wether Kafka is up.",
+		nil, labels,
+	)
+
 	clusterBrokers := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "brokers"),
 		"Number of Brokers in the Kafka Cluster.",
@@ -861,6 +878,7 @@ func (e *Exporter) initializeMetrics() {
 	)
 
 	e.promDesc = &PromDesc{
+		up:                                       up,
 		clusterBrokers:                           clusterBrokers,
 		topicPartitions:                          topicPartitions,
 		topicCurrentOffset:                       topicCurrentOffset,

--- a/inputs/kafka/kafka.go
+++ b/inputs/kafka/kafka.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	"flashcat.cloud/categraf/config"
 	"flashcat.cloud/categraf/inputs"
@@ -190,6 +191,10 @@ func (ins *Instance) Init() error {
 }
 
 func (ins *Instance) Gather(slist *types.SampleList) {
+	defer func(begun time.Time) {
+		slist.PushSample(inputName, "scrape_use_seconds", time.Since(begun).Seconds())
+	}(time.Now())
+
 	err := inputs.Collect(ins.e, slist)
 	if err != nil {
 		log.Println("E! failed to collect metrics:", err)

--- a/inputs/mongodb/mongodb.go
+++ b/inputs/mongodb/mongodb.go
@@ -3,6 +3,7 @@ package mongodb
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"flashcat.cloud/categraf/config"
 	"flashcat.cloud/categraf/inputs"
@@ -116,6 +117,10 @@ func (ins *Instance) Init() error {
 }
 
 func (ins *Instance) Gather(slist *types.SampleList) {
+	defer func(begun time.Time) {
+		slist.PushSample(inputName, "scrape_use_seconds", time.Since(begun).Seconds())
+	}(time.Now())
+
 	err := inputs.Collect(ins.e, slist)
 	if err != nil {
 		log.Println("E! failed to collect metrics:", err)


### PR DESCRIPTION
1. input.kafka supports kafka_up and kafka_scrape_use_seconds metrics
2. input.mongodb supports mongodb_scrape_use_seconds metric