### PR TITLE
Update alerts-linux.json

### DIFF
--- a/inputs/system/alerts-linux.json
+++ b/inputs/system/alerts-linux.json
@@ -95,7 +95,7 @@
       "severity": 2,
       "disabled": 0,
       "prom_for_duration": 60,
-      "prom_ql": "mem_available_percent < 25",
+      "prom_ql": "mem_used_percent > 90",
       "prom_eval_interval": 15,
       "enable_stime": "00:00",
       "enable_etime": "23:59",


### PR DESCRIPTION
告警使用mem_used_percent替代mem_available_percent
mem_available_percent指标不包含cache/buffer，容易出现误告