### PR TITLE
Feat compile prometheus alternative

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1,123 +1,63 @@
 package agent
 
 import (
+	"errors"
 	"log"
-
-	"flashcat.cloud/categraf/config"
-	"flashcat.cloud/categraf/inputs"
-	"flashcat.cloud/categraf/traces"
-
-	// auto registry
-	_ "flashcat.cloud/categraf/inputs/arp_packet"
-	_ "flashcat.cloud/categraf/inputs/conntrack"
-	_ "flashcat.cloud/categraf/inputs/cpu"
-	_ "flashcat.cloud/categraf/inputs/disk"
-	_ "flashcat.cloud/categraf/inputs/diskio"
-	_ "flashcat.cloud/categraf/inputs/dns_query"
-	_ "flashcat.cloud/categraf/inputs/docker"
-	_ "flashcat.cloud/categraf/inputs/elasticsearch"
-	_ "flashcat.cloud/categraf/inputs/exec"
-	_ "flashcat.cloud/categraf/inputs/greenplum"
-	_ "flashcat.cloud/categraf/inputs/http_response"
-	_ "flashcat.cloud/categraf/inputs/ipvs"
-	_ "flashcat.cloud/categraf/inputs/jenkins"
-	_ "flashcat.cloud/categraf/inputs/jolokia_agent"
-	_ "flashcat.cloud/categraf/inputs/jolokia_proxy"
-	_ "flashcat.cloud/categraf/inputs/kafka"
-	_ "flashcat.cloud/categraf/inputs/kernel"
-	_ "flashcat.cloud/categraf/inputs/kernel_vmstat"
-	_ "flashcat.cloud/categraf/inputs/kubernetes"
-	_ "flashcat.cloud/categraf/inputs/linux_sysctl_fs"
-	_ "flashcat.cloud/categraf/inputs/logstash"
-	_ "flashcat.cloud/categraf/inputs/mem"
-	_ "flashcat.cloud/categraf/inputs/mongodb"
-	_ "flashcat.cloud/categraf/inputs/mtail"
-	_ "flashcat.cloud/categraf/inputs/mysql"
-	_ "flashcat.cloud/categraf/inputs/net"
-	_ "flashcat.cloud/categraf/inputs/net_response"
-	_ "flashcat.cloud/categraf/inputs/netstat"
-	_ "flashcat.cloud/categraf/inputs/netstat_filter"
-	_ "flashcat.cloud/categraf/inputs/nfsclient"
-	_ "flashcat.cloud/categraf/inputs/nginx"
-	_ "flashcat.cloud/categraf/inputs/nginx_upstream_check"
-	_ "flashcat.cloud/categraf/inputs/ntp"
-	_ "flashcat.cloud/categraf/inputs/nvidia_smi"
-	_ "flashcat.cloud/categraf/inputs/oracle"
-	_ "flashcat.cloud/categraf/inputs/phpfpm"
-	_ "flashcat.cloud/categraf/inputs/ping"
-	_ "flashcat.cloud/categraf/inputs/postgresql"
-	_ "flashcat.cloud/categraf/inputs/processes"
-	_ "flashcat.cloud/categraf/inputs/procstat"
-	_ "flashcat.cloud/categraf/inputs/prometheus"
-	_ "flashcat.cloud/categraf/inputs/rabbitmq"
-	_ "flashcat.cloud/categraf/inputs/redis"
-	_ "flashcat.cloud/categraf/inputs/redis_sentinel"
-	_ "flashcat.cloud/categraf/inputs/rocketmq_offset"
-	_ "flashcat.cloud/categraf/inputs/snmp"
-	_ "flashcat.cloud/categraf/inputs/sqlserver"
-	_ "flashcat.cloud/categraf/inputs/switch_legacy"
-	_ "flashcat.cloud/categraf/inputs/system"
-	_ "flashcat.cloud/categraf/inputs/tomcat"
-	_ "flashcat.cloud/categraf/inputs/vsphere"
-	_ "flashcat.cloud/categraf/inputs/zookeeper"
 )
 
 type Agent struct {
-	InputFilters   map[string]struct{}
-	InputReaders   map[string]*InputReader
-	TraceCollector *traces.Collector
-	InputProvider  inputs.Provider
+	agents []AgentModule
 }
 
-func NewAgent(filters map[string]struct{}) (*Agent, error) {
+type AgentModule interface {
+	Start() error
+	Stop() error
+}
+
+func NewAgent() (*Agent, error) {
 	agent := &Agent{
-		InputFilters: filters,
-		InputReaders: make(map[string]*InputReader),
+		agents: []AgentModule{
+			NewMetricsAgent(),
+			NewTracesAgent(),
+			NewLogsAgent(),
+			NewPrometheusAgent(),
+		},
 	}
-
-	provider, err := inputs.NewProvider(config.Config, agent)
-	if err != nil {
-		return nil, err
-	}
-	agent.InputProvider = provider
-
-	return agent, nil
-}
-
-func (a *Agent) FilterPass(inputKey string) bool {
-	if len(a.InputFilters) > 0 {
-		// do filter
-		if _, has := a.InputFilters[inputKey]; !has {
-			return false
+	for _, ag := range agent.agents {
+		if ag != nil {
+			return agent, nil
 		}
 	}
-	return true
+	return nil, errors.New("no valid running agents, please check configuration")
 }
 
 func (a *Agent) Start() {
 	log.Println("I! agent starting")
-	a.startLogAgent()
-	err := a.startMetricsAgent()
-	if err != nil {
-		log.Println(err)
+	for _, agent := range a.agents {
+		if agent != nil {
+			err := agent.Start()
+			if err != nil {
+				log.Printf("E! start [%T] err: [%+v]", agent, err)
+			} else {
+				log.Printf("I! [%T] started", agent)
+			}
+		}
 	}
-	err = a.startTracesAgent()
-	if err != nil {
-		log.Println(err)
-	}
-	a.startPrometheusScrape()
 	log.Println("I! agent started")
 }
 
 func (a *Agent) Stop() {
 	log.Println("I! agent stopping")
-	a.stopLogAgent()
-	a.stopMetricsAgent()
-	err := a.stopTracesAgent()
-	if err != nil {
-		log.Println(err)
+	for _, agent := range a.agents {
+		if agent != nil {
+			err := agent.Stop()
+			if err != nil {
+				log.Printf("E! stop [%T] err: [%+v]", agent, err)
+			} else {
+				log.Printf("I! [%T] stopped", agent)
+			}
+		}
 	}
-	a.stopPrometheusScrape()
 	log.Println("I! agent stopped")
 }
 

--- a/agent/logs_agent.go
+++ b/agent/logs_agent.go
@@ -8,11 +8,14 @@ package agent
 import (
 	"context"
 	"errors"
+
 	"fmt"
 	"log"
 	"os"
 	"time"
 
+	coreconfig "flashcat.cloud/categraf/config"
+	logsconfig "flashcat.cloud/categraf/config/logs"
 	"flashcat.cloud/categraf/logs/auditor"
 	"flashcat.cloud/categraf/logs/client"
 	"flashcat.cloud/categraf/logs/diagnostic"
@@ -23,21 +26,29 @@ import (
 	"flashcat.cloud/categraf/logs/input/listener"
 	"flashcat.cloud/categraf/logs/pipeline"
 	"flashcat.cloud/categraf/logs/restart"
-	"flashcat.cloud/categraf/logs/status"
-
-	coreconfig "flashcat.cloud/categraf/config"
-	logsconfig "flashcat.cloud/categraf/config/logs"
 	logService "flashcat.cloud/categraf/logs/service"
+	"flashcat.cloud/categraf/logs/status"
 )
 
-// LogAgent represents the data pipeline that collects, decodes,
+const (
+	intakeTrackType         = "logs"
+	AgentJSONIntakeProtocol = "agent-json"
+	invalidProcessingRules  = "invalid_global_processing_rules"
+)
+
+// LogsAgent represents the data pipeline that collects, decodes,
 // processes and sends logs to the backend
 // + ------------------------------------------------------ +
 // |                                                        |
 // | Collector -> Decoder -> Processor -> Sender -> Auditor |
 // |                                                        |
 // + ------------------------------------------------------ +
-type LogAgent struct {
+type LogsAgent struct {
+	sources         *logsconfig.LogSources
+	services        *logService.Services
+	processingRules []*logsconfig.ProcessingRule
+	endpoints       *logsconfig.Endpoints
+
 	auditor                   auditor.Auditor
 	destinationsCtx           *client.DestinationsContext
 	pipelineProvider          pipeline.Provider
@@ -45,13 +56,38 @@ type LogAgent struct {
 	diagnosticMessageReceiver *diagnostic.BufferedMessageReceiver
 }
 
-// NewAgent returns a new Logs LogAgent
-func NewLogAgent(sources *logsconfig.LogSources, services *logService.Services, processingRules []*logsconfig.ProcessingRule, endpoints *logsconfig.Endpoints) *LogAgent {
+// NewLogsAgent returns a new Logs LogsAgent
+func NewLogsAgent() AgentModule {
+	if coreconfig.Config == nil ||
+		!coreconfig.Config.Logs.Enable ||
+		(len(coreconfig.Config.Logs.Items) == 0 && coreconfig.Config.Logs.CollectContainerAll == false) {
+		return nil
+	}
+
+	endpoints, err := BuildEndpoints(intakeTrackType, AgentJSONIntakeProtocol, logsconfig.DefaultIntakeOrigin)
+	if err != nil {
+		message := fmt.Sprintf("Invalid endpoints: %v", err)
+		status.AddGlobalError("invalid endpoints", message)
+		log.Println("E!", errors.New(message))
+		return nil
+	}
+	processingRules, err := GlobalProcessingRules()
+	if err != nil {
+		message := fmt.Sprintf("Invalid processing rules: %v", err)
+		status.AddGlobalError(invalidProcessingRules, message)
+		log.Println("E!", errors.New(message))
+		return nil
+	}
+
+	sources := logsconfig.NewLogSources()
+	services := logService.NewServices()
+	log.Println("I! Starting logs-agent...")
+
 	// setup the auditor
 	// We pass the health handle to the auditor because it's the end of the pipeline and the most
 	// critical part. Arguably it could also be plugged to the destination.
 	auditorTTL := time.Duration(23) * time.Hour
-	_, err := os.Stat(coreconfig.GetLogRunPath())
+	_, err = os.Stat(coreconfig.GetLogRunPath())
 	if os.IsNotExist(err) {
 		os.MkdirAll(coreconfig.GetLogRunPath(), 0755)
 	}
@@ -85,7 +121,11 @@ func NewLogAgent(sources *logsconfig.LogSources, services *logService.Services, 
 		inputs = append(inputs, container.NewLauncher(containerLaunchables))
 	}
 
-	return &LogAgent{
+	return &LogsAgent{
+		sources:                   sources,
+		services:                  services,
+		processingRules:           processingRules,
+		endpoints:                 endpoints,
 		auditor:                   auditor,
 		destinationsCtx:           destinationsCtx,
 		pipelineProvider:          pipelineProvider,
@@ -94,9 +134,42 @@ func NewLogAgent(sources *logsconfig.LogSources, services *logService.Services, 
 	}
 }
 
-// Start starts all the elements of the data pipeline
+func (la *LogsAgent) Start() error {
+	la.startInner()
+	if coreconfig.GetContainerCollectAll() {
+		// collect container all
+		if coreconfig.Config.DebugMode {
+			log.Println("Adding ContainerCollectAll source to the Logs Agent")
+		}
+		kubesource := logsconfig.NewLogSource(logsconfig.ContainerCollectAll,
+			&logsconfig.LogsConfig{
+				Type:    coreconfig.Kubernetes,
+				Service: "docker",
+				Source:  "docker",
+			})
+		la.sources.AddSource(kubesource)
+		go kubernetes.NewScanner(la.services).Scan()
+	}
+
+	// add source
+	for _, c := range coreconfig.Config.Logs.Items {
+		if c == nil {
+			continue
+		}
+		source := logsconfig.NewLogSource(c.Name, c)
+		if err := c.Validate(); err != nil {
+			log.Println("W! Invalid logs configuration:", err)
+			source.Status.Error(err)
+			continue
+		}
+		la.sources.AddSource(source)
+	}
+	return nil
+}
+
+// startInner starts all the elements of the data pipeline
 // in the right order to prevent data loss
-func (a *LogAgent) Start() {
+func (a *LogsAgent) startInner() {
 	starter := restart.NewStarter(a.destinationsCtx, a.auditor, a.pipelineProvider, a.diagnosticMessageReceiver)
 	for _, input := range a.inputs {
 		starter.Add(input)
@@ -104,14 +177,14 @@ func (a *LogAgent) Start() {
 	starter.Start()
 }
 
-// Flush flushes synchronously the pipelines managed by the Logs LogAgent.
-func (a *LogAgent) Flush(ctx context.Context) {
+// Flush flushes synchronously the pipelines managed by the Logs LogsAgent.
+func (a *LogsAgent) Flush(ctx context.Context) {
 	a.pipelineProvider.Flush(ctx)
 }
 
 // Stop stops all the elements of the data pipeline
 // in the right order to prevent data loss
-func (a *LogAgent) Stop() {
+func (a *LogsAgent) Stop() error {
 	inputs := restart.NewParallelStopper()
 	for _, input := range a.inputs {
 		inputs.Add(input)
@@ -150,87 +223,10 @@ func (a *LogAgent) Stop() {
 		select {
 		case <-c:
 		case <-timeout.C:
-			log.Println("W! Force close of the Logs LogAgent, dumping the Go routines.")
+			log.Println("W! Force close of the Logs LogsAgent, dumping the Go routines.")
 		}
 	}
-}
-
-var (
-	logAgent *LogAgent
-)
-
-const (
-	intakeTrackType         = "logs"
-	AgentJSONIntakeProtocol = "agent-json"
-	invalidProcessingRules  = "invalid_global_processing_rules"
-)
-
-func (a *Agent) startLogAgent() {
-	if coreconfig.Config == nil ||
-		!coreconfig.Config.Logs.Enable ||
-		(len(coreconfig.Config.Logs.Items) == 0 && coreconfig.Config.Logs.CollectContainerAll == false) {
-		return
-	}
-
-	endpoints, err := BuildEndpoints(intakeTrackType, AgentJSONIntakeProtocol, logsconfig.DefaultIntakeOrigin)
-	if err != nil {
-		message := fmt.Sprintf("Invalid endpoints: %v", err)
-		status.AddGlobalError("invalid endpoints", message)
-		log.Println("E!", errors.New(message))
-		return
-	}
-	processingRules, err := GlobalProcessingRules()
-	if err != nil {
-		message := fmt.Sprintf("Invalid processing rules: %v", err)
-		status.AddGlobalError(invalidProcessingRules, message)
-		log.Println("E!", errors.New(message))
-		return
-	}
-
-	sources := logsconfig.NewLogSources()
-	services := logService.NewServices()
-	log.Println("I! Starting logs-agent...")
-	logAgent = NewLogAgent(sources, services, processingRules, endpoints)
-	logAgent.Start()
-
-	if coreconfig.GetContainerCollectAll() {
-		// collect container all
-		if coreconfig.Config.DebugMode {
-			log.Println("Adding ContainerCollectAll source to the Logs Agent")
-		}
-		kubesource := logsconfig.NewLogSource(logsconfig.ContainerCollectAll,
-			&logsconfig.LogsConfig{
-				Type:    coreconfig.Kubernetes,
-				Service: "docker",
-				Source:  "docker",
-			})
-		sources.AddSource(kubesource)
-		go kubernetes.NewScanner(services).Scan()
-	}
-
-	// add source
-	for _, c := range coreconfig.Config.Logs.Items {
-		if c == nil {
-			continue
-		}
-		source := logsconfig.NewLogSource(c.Name, c)
-		if err := c.Validate(); err != nil {
-			log.Println("W! Invalid logs configuration:", err)
-			source.Status.Error(err)
-			continue
-		}
-		sources.AddSource(source)
-	}
-}
-
-func (a *Agent) stopLogAgent() {
-	if logAgent != nil {
-		logAgent.Stop()
-	}
-}
-
-func GetContainerColloectAll() bool {
-	return false
+	return nil
 }
 
 // GlobalProcessingRules returns the global processing rules to apply to all logs.

--- a/agent/logs_agent.go
+++ b/agent/logs_agent.go
@@ -8,14 +8,11 @@ package agent
 import (
 	"context"
 	"errors"
-
 	"fmt"
 	"log"
 	"os"
 	"time"
 
-	coreconfig "flashcat.cloud/categraf/config"
-	logsconfig "flashcat.cloud/categraf/config/logs"
 	"flashcat.cloud/categraf/logs/auditor"
 	"flashcat.cloud/categraf/logs/client"
 	"flashcat.cloud/categraf/logs/diagnostic"
@@ -26,8 +23,11 @@ import (
 	"flashcat.cloud/categraf/logs/input/listener"
 	"flashcat.cloud/categraf/logs/pipeline"
 	"flashcat.cloud/categraf/logs/restart"
-	logService "flashcat.cloud/categraf/logs/service"
 	"flashcat.cloud/categraf/logs/status"
+
+	coreconfig "flashcat.cloud/categraf/config"
+	logsconfig "flashcat.cloud/categraf/config/logs"
+	logService "flashcat.cloud/categraf/logs/service"
 )
 
 const (

--- a/agent/metrics_agent.go
+++ b/agent/metrics_agent.go
@@ -98,7 +98,9 @@ func (ma *MetricsAgent) FilterPass(inputKey string) bool {
 }
 
 func (ma *MetricsAgent) Start() error {
-	ma.InputProvider.LoadConfig()
+	if _, err := ma.InputProvider.LoadConfig(); err != nil {
+		log.Println("E! input provider load config get err: ", err)
+	}
 	ma.InputProvider.StartReloader()
 
 	names, err := ma.InputProvider.GetInputs()

--- a/agent/metrics_agent.go
+++ b/agent/metrics_agent.go
@@ -1,16 +1,107 @@
 package agent
 
 import (
+	"errors"
 	"log"
+	"strings"
 
+	"flashcat.cloud/categraf/config"
 	"flashcat.cloud/categraf/inputs"
+	"flashcat.cloud/categraf/pkg/cfg"
+	"flashcat.cloud/categraf/types"
+
+	// auto registry
+	_ "flashcat.cloud/categraf/inputs/arp_packet"
+	_ "flashcat.cloud/categraf/inputs/conntrack"
+	_ "flashcat.cloud/categraf/inputs/cpu"
+	_ "flashcat.cloud/categraf/inputs/disk"
+	_ "flashcat.cloud/categraf/inputs/diskio"
+	_ "flashcat.cloud/categraf/inputs/dns_query"
+	_ "flashcat.cloud/categraf/inputs/docker"
+	_ "flashcat.cloud/categraf/inputs/elasticsearch"
+	_ "flashcat.cloud/categraf/inputs/exec"
+	_ "flashcat.cloud/categraf/inputs/greenplum"
+	_ "flashcat.cloud/categraf/inputs/http_response"
+	_ "flashcat.cloud/categraf/inputs/ipvs"
+	_ "flashcat.cloud/categraf/inputs/jenkins"
+	_ "flashcat.cloud/categraf/inputs/jolokia_agent"
+	_ "flashcat.cloud/categraf/inputs/jolokia_proxy"
+	_ "flashcat.cloud/categraf/inputs/kafka"
+	_ "flashcat.cloud/categraf/inputs/kernel"
+	_ "flashcat.cloud/categraf/inputs/kernel_vmstat"
+	_ "flashcat.cloud/categraf/inputs/kubernetes"
+	_ "flashcat.cloud/categraf/inputs/linux_sysctl_fs"
+	_ "flashcat.cloud/categraf/inputs/logstash"
+	_ "flashcat.cloud/categraf/inputs/mem"
+	_ "flashcat.cloud/categraf/inputs/mongodb"
+	_ "flashcat.cloud/categraf/inputs/mtail"
+	_ "flashcat.cloud/categraf/inputs/mysql"
+	_ "flashcat.cloud/categraf/inputs/net"
+	_ "flashcat.cloud/categraf/inputs/net_response"
+	_ "flashcat.cloud/categraf/inputs/netstat"
+	_ "flashcat.cloud/categraf/inputs/netstat_filter"
+	_ "flashcat.cloud/categraf/inputs/nfsclient"
+	_ "flashcat.cloud/categraf/inputs/nginx"
+	_ "flashcat.cloud/categraf/inputs/nginx_upstream_check"
+	_ "flashcat.cloud/categraf/inputs/ntp"
+	_ "flashcat.cloud/categraf/inputs/nvidia_smi"
+	_ "flashcat.cloud/categraf/inputs/oracle"
+	_ "flashcat.cloud/categraf/inputs/phpfpm"
+	_ "flashcat.cloud/categraf/inputs/ping"
+	_ "flashcat.cloud/categraf/inputs/postgresql"
+	_ "flashcat.cloud/categraf/inputs/processes"
+	_ "flashcat.cloud/categraf/inputs/procstat"
+	_ "flashcat.cloud/categraf/inputs/prometheus"
+	_ "flashcat.cloud/categraf/inputs/rabbitmq"
+	_ "flashcat.cloud/categraf/inputs/redis"
+	_ "flashcat.cloud/categraf/inputs/redis_sentinel"
+	_ "flashcat.cloud/categraf/inputs/rocketmq_offset"
+	_ "flashcat.cloud/categraf/inputs/snmp"
+	_ "flashcat.cloud/categraf/inputs/sqlserver"
+	_ "flashcat.cloud/categraf/inputs/switch_legacy"
+	_ "flashcat.cloud/categraf/inputs/system"
+	_ "flashcat.cloud/categraf/inputs/tomcat"
+	_ "flashcat.cloud/categraf/inputs/vsphere"
+	_ "flashcat.cloud/categraf/inputs/zookeeper"
 )
 
-func (a *Agent) startMetricsAgent() error {
-	a.InputProvider.LoadConfig()
-	a.InputProvider.StartReloader()
+type MetricsAgent struct {
+	InputFilters  map[string]struct{}
+	InputReaders  map[string]*InputReader
+	InputProvider inputs.Provider
+}
 
-	names, err := a.InputProvider.GetInputs()
+func NewMetricsAgent() AgentModule {
+	c := config.Config
+	agent := &MetricsAgent{
+		InputFilters: parseFilter(c.InputFilters),
+		InputReaders: make(map[string]*InputReader),
+	}
+
+	provider, err := inputs.NewProvider(c, agent)
+	if err != nil {
+		log.Println("E! init metrics agent error: ", err)
+		return nil
+	}
+	agent.InputProvider = provider
+	return agent
+}
+
+func (ma *MetricsAgent) FilterPass(inputKey string) bool {
+	if len(ma.InputFilters) > 0 {
+		// do filter
+		if _, has := ma.InputFilters[inputKey]; !has {
+			return false
+		}
+	}
+	return true
+}
+
+func (ma *MetricsAgent) Start() error {
+	ma.InputProvider.LoadConfig()
+	ma.InputProvider.StartReloader()
+
+	names, err := ma.InputProvider.GetInputs()
 	if err != nil {
 		return err
 	}
@@ -22,24 +113,114 @@ func (a *Agent) startMetricsAgent() error {
 
 	for _, name := range names {
 		_, inputKey := inputs.ParseInputName(name)
-		if !a.FilterPass(inputKey) {
+		if !ma.FilterPass(inputKey) {
 			continue
 		}
 
-		configs, err := a.InputProvider.GetInputConfig(name)
+		configs, err := ma.InputProvider.GetInputConfig(name)
 		if err != nil {
 			log.Println("E! failed to get configuration of plugin:", name, "error:", err)
 			continue
 		}
 
-		a.RegisterInput(name, configs)
+		ma.RegisterInput(name, configs)
 	}
 	return nil
 }
 
-func (a *Agent) stopMetricsAgent() {
-	a.InputProvider.StopReloader()
-	for name := range a.InputReaders {
-		a.InputReaders[name].Stop()
+func (ma *MetricsAgent) Stop() error {
+	ma.InputProvider.StopReloader()
+	for name := range ma.InputReaders {
+		ma.InputReaders[name].Stop()
 	}
+	return nil
+}
+
+func (ma *MetricsAgent) RegisterInput(name string, configs []cfg.ConfigWithFormat) {
+	_, inputKey := inputs.ParseInputName(name)
+	if !ma.FilterPass(inputKey) {
+		return
+	}
+
+	creator, has := inputs.InputCreators[inputKey]
+	if !has {
+		log.Println("E! input:", name, "not supported")
+		return
+	}
+
+	// construct input instance
+	input := creator()
+
+	err := cfg.LoadConfigs(configs, input)
+	if err != nil {
+		log.Println("E! failed to load configuration of plugin:", name, "error:", err)
+		return
+	}
+
+	if err = input.InitInternalConfig(); err != nil {
+		log.Println("E! failed to init input:", name, "error:", err)
+		return
+	}
+
+	if err = inputs.MayInit(input); err != nil {
+		if !errors.Is(err, types.ErrInstancesEmpty) {
+			log.Println("E! failed to init input:", name, "error:", err)
+		}
+		return
+	}
+
+	instances := inputs.MayGetInstances(input)
+	if instances != nil {
+		empty := true
+		for i := 0; i < len(instances); i++ {
+			if err := instances[i].InitInternalConfig(); err != nil {
+				log.Println("E! failed to init input:", name, "error:", err)
+				continue
+			}
+
+			if err := inputs.MayInit(instances[i]); err != nil {
+				if !errors.Is(err, types.ErrInstancesEmpty) {
+					log.Println("E! failed to init input:", name, "error:", err)
+				}
+				continue
+			}
+			empty = false
+		}
+
+		if empty {
+			return
+		}
+	}
+
+	reader := newInputReader(name, input)
+	go reader.startInput()
+	ma.InputReaders[name] = reader
+	log.Println("I! input:", name, "started")
+}
+
+func (ma *MetricsAgent) DeregisterInput(name string) {
+	if reader, has := ma.InputReaders[name]; has {
+		reader.Stop()
+		delete(ma.InputReaders, name)
+		log.Println("I! input:", name, "stopped")
+	} else {
+		log.Printf("W! dereigster input name [%s] not found", name)
+	}
+}
+
+func (ma *MetricsAgent) ReregisterInput(name string, configs []cfg.ConfigWithFormat) {
+	ma.DeregisterInput(name)
+	ma.RegisterInput(name, configs)
+}
+
+func parseFilter(filterStr string) map[string]struct{} {
+	filters := strings.Split(filterStr, ":")
+	filtermap := make(map[string]struct{})
+	for i := 0; i < len(filters); i++ {
+		if strings.TrimSpace(filters[i]) == "" {
+			continue
+		}
+		filtermap[filters[i]] = struct{}{}
+	}
+	return filtermap
 }

--- a/agent/prometheus_agent.go
+++ b/agent/prometheus_agent.go
@@ -1,3 +1,5 @@
+//go:build !no_prometheus
+
 package agent
 
 import (
@@ -7,23 +9,32 @@ import (
 	"flashcat.cloud/categraf/prometheus"
 )
 
-func (a *Agent) startPrometheusScrape() {
+type PrometheusAgent struct {
+}
+
+func NewPrometheusAgent() AgentModule {
+	return &PrometheusAgent{}
+}
+
+func (pa *PrometheusAgent) Start() error {
 	if coreconfig.Config == nil ||
 		coreconfig.Config.Prometheus == nil ||
 		!coreconfig.Config.Prometheus.Enable {
 		log.Println("I! prometheus scraping disabled!")
-		return
+		return nil
 	}
 	go prometheus.Start()
 	log.Println("I! prometheus scraping started!")
+	return nil
 }
 
-func (a *Agent) stopPrometheusScrape() {
+func (pa *PrometheusAgent) Stop() error {
 	if coreconfig.Config == nil ||
 		coreconfig.Config.Prometheus == nil ||
 		!coreconfig.Config.Prometheus.Enable {
-		return
+		return nil
 	}
 	prometheus.Stop()
 	log.Println("I! prometheus scraping stopped!")
+	return nil
 }

--- a/agent/promethues_agent_none.go
+++ b/agent/promethues_agent_none.go
@@ -1,0 +1,18 @@
+//go:build no_prometheus
+
+package agent
+
+type PrometheusAgent struct {
+}
+
+func NewPrometheusAgent() AgentModule {
+	return &PrometheusAgent{}
+}
+
+func (pa *PrometheusAgent) Start() error {
+	return nil
+}
+
+func (pa *PrometheusAgent) Stop() error {
+	return nil
+}

--- a/agent/traces_agent.go
+++ b/agent/traces_agent.go
@@ -8,7 +8,15 @@ import (
 	"flashcat.cloud/categraf/traces"
 )
 
-func (a *Agent) startTracesAgent() (err error) {
+type TracesAgent struct {
+	TraceCollector *traces.Collector
+}
+
+func NewTracesAgent() AgentModule {
+	return &TracesAgent{}
+}
+
+func (ta *TracesAgent) Start() (err error) {
 	if config.Config.Traces == nil || !config.Config.Traces.Enable {
 		return nil
 	}
@@ -29,16 +37,16 @@ func (a *Agent) startTracesAgent() (err error) {
 		return err
 	}
 
-	a.TraceCollector = col
+	ta.TraceCollector = col
 	return nil
 }
 
-func (a *Agent) stopTracesAgent() (err error) {
+func (ta *TracesAgent) Stop() (err error) {
 	if config.Config.Traces == nil || !config.Config.Traces.Enable {
 		return nil
 	}
 
-	if a.TraceCollector == nil {
+	if ta.TraceCollector == nil {
 		return nil
 	}
 
@@ -48,5 +56,5 @@ func (a *Agent) stopTracesAgent() (err error) {
 		}
 	}()
 
-	return a.TraceCollector.Shutdown(context.Background())
+	return ta.TraceCollector.Shutdown(context.Background())
 }

--- a/config/config.go
+++ b/config/config.go
@@ -60,9 +60,10 @@ type HTTP struct {
 
 type ConfigType struct {
 	// from console args
-	ConfigDir string
-	DebugMode bool
-	TestMode  bool
+	ConfigDir    string
+	DebugMode    bool
+	TestMode     bool
+	InputFilters string
 
 	DisableUsageReport bool `toml:"disable_usage_report"`
 
@@ -81,16 +82,17 @@ type ConfigType struct {
 
 var Config *ConfigType
 
-func InitConfig(configDir string, debugMode, testMode bool, interval int64) error {
+func InitConfig(configDir string, debugMode, testMode bool, interval int64, inputFilters string) error {
 	configFile := path.Join(configDir, "config.toml")
 	if !file.IsExist(configFile) {
 		return fmt.Errorf("configuration file(%s) not found", configFile)
 	}
 
 	Config = &ConfigType{
-		ConfigDir: configDir,
-		DebugMode: debugMode,
-		TestMode:  testMode,
+		ConfigDir:    configDir,
+		DebugMode:    debugMode,
+		TestMode:     testMode,
+		InputFilters: inputFilters,
 	}
 
 	if err := cfg.LoadConfigByDir(configDir, Config); err != nil {

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"strings"
 	"syscall"
 
 	"flashcat.cloud/categraf/agent"
@@ -53,7 +52,7 @@ func main() {
 	printEnv()
 
 	// init configs
-	if err := config.InitConfig(*configDir, *debugMode, *testMode, *interval); err != nil {
+	if err := config.InitConfig(*configDir, *debugMode, *testMode, *interval, *inputFilters); err != nil {
 		log.Fatalln("F! failed to init config:", err)
 	}
 
@@ -62,7 +61,7 @@ func main() {
 	go api.Start()
 	go agent.Report()
 
-	ag, err := agent.NewAgent(parseFilter(*inputFilters))
+	ag, err := agent.NewAgent()
 	if err != nil {
 		fmt.Println("F! failed to init agent:", err)
 		os.Exit(-1)
@@ -111,16 +110,4 @@ func printEnv() {
 	log.Println("I! runner.hostname:", runner.Hostname)
 	log.Println("I! runner.fd_limits:", runner.FdLimits())
 	log.Println("I! runner.vm_limits:", runner.VMLimits())
-}
-
-func parseFilter(filterStr string) map[string]struct{} {
-	filters := strings.Split(filterStr, ":")
-	filtermap := make(map[string]struct{})
-	for i := 0; i < len(filters); i++ {
-		if strings.TrimSpace(filters[i]) == "" {
-			continue
-		}
-		filtermap[filters[i]] = struct{}{}
-	}
-	return filtermap
 }

--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -1,3 +1,5 @@
+//go:build !no_prometheus
+
 package prometheus
 
 import (


### PR DESCRIPTION
1. 代码重构，统一agent定义，相关数据结构由对应agent自己管理
2. 添加prometheus scrape模块的条件编译，macos上测试不编译promehteus scrape包大小由150MB减少到77MB