### PR TITLE
opt: writers code refactor

### DIFF
--- a/agent/metrics_reader.go
+++ b/agent/metrics_reader.go
@@ -110,6 +110,6 @@ func (r *InputReader) forward(slist *types.SampleList) {
 	}
 	arr := slist.PopBackAll()
 	for i := 0; i < len(arr); i++ {
-		writer.PushQueue(arr[i])
+		writer.WriteSample(arr[i])
 	}
 }

--- a/api/router_falcon.go
+++ b/api/router_falcon.go
@@ -209,6 +209,6 @@ func openFalcon(c *gin.Context) {
 		log.Println("falcon forwarder error, message:", string(bytes))
 	}
 
-	writer.PostTimeSeries(series)
+	writer.WriteTimeSeries(series)
 	c.String(200, "succ:%d fail:%d message:%s", succ, fail, msg)
 }

--- a/api/router_opentsdb.go
+++ b/api/router_opentsdb.go
@@ -194,6 +194,6 @@ func openTSDB(c *gin.Context) {
 		log.Println("opentsdb forwarder error, message:", string(bytes))
 	}
 
-	writer.PostTimeSeries(series)
+	writer.WriteTimeSeries(series)
 	c.String(200, "succ:%d fail:%d message:%s", succ, fail, msg)
 }

--- a/api/router_pushgateway.go
+++ b/api/router_pushgateway.go
@@ -63,7 +63,7 @@ func pushgateway(c *gin.Context) {
 			samples[i].Labels[agentHostnameLabelKey] = config.Config.GetHostname()
 		}
 
-		writer.PushQueue(samples[i])
+		writer.WriteSample(samples[i])
 	}
 
 	c.String(200, "forwarding...")

--- a/api/router_remotewrite.go
+++ b/api/router_remotewrite.go
@@ -49,7 +49,7 @@ func remoteWrite(c *gin.Context) {
 		}
 	}
 
-	writer.PostTimeSeries(req.Timeseries)
+	writer.WriteTimeSeries(req.Timeseries)
 	c.String(200, "forwarding...")
 }
 

--- a/writer/queue.go
+++ b/writer/queue.go
@@ -3,36 +3,42 @@ package writer
 import (
 	"time"
 
-	"flashcat.cloud/categraf/config"
-	"flashcat.cloud/categraf/types"
+	"github.com/prometheus/prometheus/prompb"
 )
 
-var queue chan *types.Sample
-
-func PushQueue(s *types.Sample) {
-	queue <- s
+type MetricQueue struct {
+	queue         chan *prompb.TimeSeries
+	batch         int
+	flushCallBack func([]prompb.TimeSeries)
 }
 
-func initQueue() {
-	queue = make(chan *types.Sample, config.Config.WriterOpt.ChanSize)
-	go readQueue(queue)
-}
-
-func readQueue(queue chan *types.Sample) {
-	batch := config.Config.WriterOpt.Batch
+func newMetricQueue(batch int, flushCallback func([]prompb.TimeSeries)) MetricQueue {
 	if batch <= 0 {
 		batch = 2000
 	}
+	return MetricQueue{
+		queue:         make(chan *prompb.TimeSeries, batch),
+		batch:         batch,
+		flushCallBack: flushCallback,
+	}
+}
 
-	series := make([]*types.Sample, 0, batch)
+func (mq *MetricQueue) Push(s *prompb.TimeSeries) {
+	if s == nil {
+		return
+	}
+	mq.queue <- s
+}
 
+func (mq *MetricQueue) LoopRead() {
+	series := make([]prompb.TimeSeries, 0, mq.batch)
 	var count int
-
 	for {
 		select {
-		case item, open := <-queue:
+		case item, open := <-mq.queue:
 			if !open {
-				// queue closed
+				// queue closed, post remaining series
+				mq.flushCallBack(series)
 				return
 			}
 
@@ -40,17 +46,17 @@ func readQueue(queue chan *types.Sample) {
 				continue
 			}
 
-			series = append(series, item)
+			series = append(series, *item)
 			count++
-			if count >= batch {
-				postSeries(series)
+			if count >= mq.batch {
+				mq.flushCallBack(series)
 				count = 0
 				// reset series slice, do not release memory
 				series = series[:0]
 			}
 		default:
 			if len(series) > 0 {
-				postSeries(series)
+				mq.flushCallBack(series)
 				count = 0
 				// reset series slice, do not release memory
 				series = series[:0]

--- a/writer/writers.go
+++ b/writer/writers.go
@@ -1,13 +1,15 @@
 package writer
 
 import (
-	"flashcat.cloud/categraf/config"
-	"flashcat.cloud/categraf/types"
 	"fmt"
-	"github.com/prometheus/prometheus/prompb"
 	"sort"
 	"strings"
 	"sync"
+
+	"github.com/prometheus/prometheus/prompb"
+
+	"flashcat.cloud/categraf/config"
+	"flashcat.cloud/categraf/types"
 )
 
 // Writers manage all writers and metric queue

--- a/writer/writers.go
+++ b/writer/writers.go
@@ -15,9 +15,15 @@ import (
 	"github.com/prometheus/prometheus/prompb"
 )
 
-var Writers = make(map[string]WriterType)
+type Writers struct {
+	writerMap map[string]WriterType
+	queue     MetricQueue
+}
+
+var writers Writers
 
 func InitWriters() error {
+	writerMap := map[string]WriterType{}
 	opts := config.Config.Writers
 	for i := 0; i < len(opts); i++ {
 		cli, err := api.NewClient(api.Config{
@@ -41,78 +47,74 @@ func InitWriters() error {
 			Opts:   opts[i],
 			Client: cli,
 		}
-
-		Writers[opts[i].Url] = writer
+		writerMap[opts[i].Url] = writer
 	}
 
-	initQueue()
+	writers = Writers{
+		writerMap: writerMap,
+		queue:     newMetricQueue(config.Config.WriterOpt.ChanSize, WriteTimeSeries),
+	}
 
+	go writers.queue.LoopRead()
 	return nil
 }
 
-func postSeries(samples []*types.Sample) {
-	if config.Config.TestMode {
-		printTestMetrics(samples)
+func WriteSample(sample *types.Sample) {
+	if sample == nil {
 		return
-	} else {
-		if config.Config.DebugMode {
-			printTestMetrics(samples)
-		}
+	}
+	if config.Config.TestMode {
+		printTestMetric(sample)
+		return
+	}
+	if config.Config.DebugMode {
+		printTestMetric(sample)
 	}
 
-	count := len(samples)
-	series := make([]prompb.TimeSeries, 0, count)
-	for i := 0; i < count; i++ {
-		item := samples[i].ConvertTimeSeries(config.Config.Global.Precision)
-		if item == nil || len(item.Labels) == 0 {
-			continue
-		}
-
-		series = append(series, *item)
+	item := sample.ConvertTimeSeries(config.Config.Global.Precision)
+	if item == nil || len(item.Labels) == 0 {
+		return
 	}
-
-	PostTimeSeries(series)
+	writers.queue.Push(item)
 }
 
-func PostTimeSeries(timeSeries []prompb.TimeSeries) {
+func WriteTimeSeries(timeSeries []prompb.TimeSeries) {
 	if len(timeSeries) == 0 {
 		return
 	}
 
 	wg := sync.WaitGroup{}
-	for key := range Writers {
+	for key := range writers.writerMap {
 		wg.Add(1)
 		go func(key string) {
 			defer wg.Done()
-			Writers[key].Write(timeSeries)
+			writers.writerMap[key].Write(timeSeries)
 		}(key)
 	}
 	wg.Wait()
 }
 
-func printTestMetrics(samples []*types.Sample) {
-	for i := 0; i < len(samples); i++ {
-		var sb strings.Builder
+func printTestMetric(sample *types.Sample) {
+	var sb strings.Builder
 
-		sb.WriteString(samples[i].Timestamp.Format("15:04:05"))
-		sb.WriteString(" ")
-		sb.WriteString(samples[i].Metric)
+	sb.WriteString(sample.Timestamp.Format("15:04:05"))
+	sb.WriteString(" ")
+	sb.WriteString(sample.Metric)
 
-		arr := make([]string, 0, len(samples[i].Labels))
-		for key, val := range samples[i].Labels {
-			arr = append(arr, fmt.Sprintf("%s=%v", key, val))
-		}
-
-		sort.Strings(arr)
-
-		for _, pair := range arr {
-			sb.WriteString(" ")
-			sb.WriteString(pair)
-		}
-
-		sb.WriteString(" ")
-		sb.WriteString(fmt.Sprint(samples[i].Value))
-
-		fmt.Println(sb.String())
+	arr := make([]string, 0, len(sample.Labels))
+	for key, val := range sample.Labels {
+		arr = append(arr, fmt.Sprintf("%s=%v", key, val))
 	}
+
+	sort.Strings(arr)
+
+	for _, pair := range arr {
+		sb.WriteString(" ")
+		sb.WriteString(pair)
+	}
+
+	sb.WriteString(" ")
+	sb.WriteString(fmt.Sprint(sample.Value))
+
+	fmt.Println(sb.String())
 }


### PR DESCRIPTION
1. 当queue close时，flush还在队列里面的指标
2. queue中管理timeseries，替代原来的types.samples
3. queue、writer、writers的实现解耦；面向对象改造