### PR TITLE
comment out input.prometheus.instances.urls dirty data

### DIFF
--- a/conf/input.prometheus/prometheus.toml
+++ b/conf/input.prometheus/prometheus.toml
@@ -3,7 +3,7 @@
 
 [[instances]]
 urls = [
-     "http://localhost:19000/metrics"
+#     "http://localhost:19000/metrics"
 ]
 
 url_label_key = "instance"


### PR DESCRIPTION
注释掉 input.prometheus.instances.urls 中的 http://localhost:19000/metrics 脏数据；
否则默认启动categraf后通常会报错： 2022/12/20 14:55:47 prometheus.go:208: E! failed to query url: http://localhost:19000/metrics error: Get "http://localhost:19000/metrics": dial tcp [::1]:19000: connect: connection refused
让运维方产生误解;