### PR TITLE
use volume for prometheus wal

### DIFF
--- a/k8s/deployment-etcd-http.yaml
+++ b/k8s/deployment-etcd-http.yaml
@@ -109,6 +109,8 @@ data:
     log_level="info"
     ## wal reserve time duration, default value is 2 hour
     # wal_min_duration=2
+    ## wal storage path, default value is ./data-agent
+    wal_storage_path="/opt/categraf/prometheus-wal"
 ---
 kind: ConfigMap
 metadata:
@@ -258,6 +260,8 @@ spec:
           name: categraf-config
         - mountPath: /opt/categraf/scrape
           name: scrape-config
+        - mountPath: /opt/categraf/prometheus-wal
+          name: prometheus-wal
       dnsPolicy: ClusterFirst
       hostNetwork: false
       restartPolicy: Always
@@ -277,3 +281,5 @@ spec:
           defaultMode: 420
           name: scrape-config
         name: scrape-config
+      - emptyDir: {}
+        name: prometheus-wal

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -121,6 +121,8 @@ data:
     log_level="info"
     ## wal reserve time duration, default value is 2 hour
     # wal_min_duration=2
+    ## wal storage path, default value is ./data-agent
+    wal_storage_path="/opt/categraf/prometheus-wal"
 ---
 kind: ConfigMap
 metadata:
@@ -277,6 +279,8 @@ spec:
           name: scrape-config
         - mountPath: /opt/categraf/pki/etcd
           name: etcd-pki
+        - mountPath: /opt/categraf/prometheus-wal
+          name: prometheus-wal
       dnsPolicy: ClusterFirst
       hostNetwork: false
       restartPolicy: Always
@@ -299,3 +303,5 @@ spec:
       - configMap:
           name: etcd-pki
         name: etcd-pki
+      - emptyDir: {}
+        name: prometheus-wal


### PR DESCRIPTION
when categraf is deployed in kubernetes, it's prometheus-agent default use ./data-agent as wal path, which is path of container filesystem(eg.overlayfs). 

usually host volume of container has better i/o performance than container filesystem, so we can config prometheus-agent to use emptyDir volume, which is a temp host volume with pod lifecycle.
