### PR TITLE
Feat input sockstat

### DIFF
--- a/agent/metrics_agent.go
+++ b/agent/metrics_agent.go
@@ -58,6 +58,7 @@ import (
 	_ "flashcat.cloud/categraf/inputs/redis_sentinel"
 	_ "flashcat.cloud/categraf/inputs/rocketmq_offset"
 	_ "flashcat.cloud/categraf/inputs/snmp"
+	_ "flashcat.cloud/categraf/inputs/sockstat"
 	_ "flashcat.cloud/categraf/inputs/sqlserver"
 	_ "flashcat.cloud/categraf/inputs/switch_legacy"
 	_ "flashcat.cloud/categraf/inputs/system"

--- a/conf/input.netstat/netstat.toml
+++ b/conf/input.netstat/netstat.toml
@@ -1,5 +1,8 @@
 # # collect interval
 # interval = 15
 
+## if machine has many network connections, use this plugin may exhaust your cpu resource, diable connection stat to avoid this
+disable_connection_stats = false
+
 tcp_ext = false
 ip_ext = false

--- a/conf/input.sockstat/sockstat.toml
+++ b/conf/input.sockstat/sockstat.toml
@@ -1,0 +1,4 @@
+
+# sockstat
+## protocol to collect, valid values are "tcp", "udp", "tcp6", "udp6", "udplite", "raw", "frag", "udplite6", "raw6", "frag6"
+protocols = ["tcp", "udp", "tcp6", "udp6"]

--- a/inputs/netstat/ext_linux.go
+++ b/inputs/netstat/ext_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package netstat
 

--- a/inputs/netstat/ext_notlinux.go
+++ b/inputs/netstat/ext_notlinux.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package netstat
 

--- a/inputs/netstat/netstat.go
+++ b/inputs/netstat/netstat.go
@@ -16,8 +16,9 @@ type NetStats struct {
 	ps system.PS
 	config.PluginConfig
 
-	TcpExt bool `toml:"tcp_ext"`
-	IpExt  bool `toml:"ip_ext"`
+	DisableConnectionStats bool `toml:"disable_connection_stats"`
+	TcpExt                 bool `toml:"tcp_ext"`
+	IpExt                  bool `toml:"ip_ext"`
 }
 
 func init() {
@@ -30,6 +31,11 @@ func init() {
 }
 
 func (s *NetStats) Gather(slist *types.SampleList) {
+	s.gatherExt(slist)
+
+	if s.DisableConnectionStats {
+		return
+	}
 	netconns, err := s.ps.NetConnections()
 	if err != nil {
 		log.Println("E! failed to get net connections:", err)
@@ -70,8 +76,10 @@ func (s *NetStats) Gather(slist *types.SampleList) {
 	}
 
 	slist.PushSamples(inputName, fields, tags)
+}
 
-	s.gatherExt(slist)
+func (s *NetStats) gatherNetStat(slist *types.SampleList) {
+
 }
 
 func (s *NetStats) gatherExt(slist *types.SampleList) {

--- a/inputs/sockstat/README.md
+++ b/inputs/sockstat/README.md
@@ -1,0 +1,27 @@
+# Read sockstat info from /proc/net/sockstat and /proc/net/sockstat6
+
+## example file
+```shell
+sockets: used 211
+TCP: inuse 9 orphan 0 tw 19 alloc 47 mem 22
+UDP: inuse 2 mem 0
+UDPLITE: inuse 0
+RAW: inuse 0
+FRAG: inuse 0 memory 0
+```
+
+The content of "/proc/net/sockstat" in a Linux system provides information about the socket usage on the system. The fields and their meaning are as follows:
+
+sockets: used: Total number of used sockets on the system.
+TCP: inuse: Number of currently established TCP sockets.
+orphan: Number of orphaned TCP sockets.
+tw: Number of sockets in TIME_WAIT state.
+alloc: Number of sockets allocated.
+mem: Memory used by TCP sockets.
+UDP: inuse: Number of currently established UDP sockets.
+mem: Memory used by UDP sockets.
+UDPLITE: inuse: Number of currently established UDP-Lite sockets.
+RAW: inuse: Number of currently established raw sockets.
+FRAG: inuse: Number of currently established fragment sockets.
+memory: Memory used by fragment sockets.
+These fields provide a snapshot of the socket usage on the system, including the number of sockets in use and memory usage, which can be useful for monitoring and troubleshooting network issues.

--- a/inputs/sockstat/sockstat.go
+++ b/inputs/sockstat/sockstat.go
@@ -4,10 +4,11 @@ import (
 	"log"
 	"strings"
 
+	"github.com/toolkits/pkg/slice"
+
 	"flashcat.cloud/categraf/config"
 	"flashcat.cloud/categraf/inputs"
 	"flashcat.cloud/categraf/types"
-	"github.com/toolkits/pkg/slice"
 )
 
 const inputName = "sockstat"

--- a/inputs/sockstat/sockstat.go
+++ b/inputs/sockstat/sockstat.go
@@ -1,0 +1,96 @@
+package sockstat
+
+import (
+	"log"
+	"strings"
+
+	"flashcat.cloud/categraf/config"
+	"flashcat.cloud/categraf/inputs"
+	"flashcat.cloud/categraf/types"
+	"github.com/toolkits/pkg/slice"
+)
+
+const inputName = "sockstat"
+
+func init() {
+	inputs.Add(inputName, func() inputs.Input {
+		return &SockStat{}
+	})
+}
+
+type SockStat struct {
+	config.PluginConfig
+
+	Protocols []string `toml:"protocols"`
+}
+
+// A NetSockstat contains the output of /proc/net/sockstat{,6} for IPv4 or IPv6,
+// respectively.
+type NetSockstat struct {
+	// Used is non-nil for IPv4 sockstat results, but nil for IPv6.
+	Used      *int
+	Protocols []NetSockstatProtocol
+}
+
+// A NetSockstatProtocol contains statistics about a given socket protocol.
+// Pointer fields indicate that the value may or may not be present on any
+// given protocol.
+type NetSockstatProtocol struct {
+	Protocol string
+	InUse    int
+	Orphan   *int
+	TW       *int
+	Alloc    *int
+	Mem      *int
+	Memory   *int
+}
+
+func (ss *SockStat) Gather(slist *types.SampleList) {
+	ns, err := ParseNetSockstat()
+	if err != nil {
+		log.Println("E! failed to get net sockstat: ", err)
+		return
+	}
+	ss.parse(ns, slist)
+
+	ns6, err := ParseNetSockstat6()
+	if err != nil {
+		log.Println("E! failed to get net sockstat6: ", err)
+		return
+	}
+	ss.parse(ns6, slist)
+}
+
+func (ss *SockStat) parse(ns *NetSockstat, slist *types.SampleList) {
+	if ns == nil {
+		return
+	}
+	samples := map[string]interface{}{}
+	if ns.Used != nil {
+		samples["used"] = *ns.Used
+	}
+
+	for _, p := range ns.Protocols {
+		protocol := strings.ToLower(p.Protocol)
+		if len(ss.Protocols) > 0 && !slice.ContainsString(ss.Protocols, protocol) {
+			continue
+		}
+		samples[protocol+"_inuse"] = p.InUse
+		if p.Orphan != nil {
+			samples[protocol+"_orphan"] = *p.Orphan
+		}
+		if p.TW != nil {
+			samples[protocol+"_tw"] = *p.TW
+		}
+		if p.Alloc != nil {
+			samples[protocol+"_alloc"] = *p.Alloc
+		}
+		if p.Mem != nil {
+			samples[protocol+"_mem"] = *p.Mem
+		}
+		if p.Memory != nil {
+			samples[protocol+"_memory"] = *p.Memory
+		}
+	}
+	slist.PushSamples(inputName, samples)
+}

--- a/inputs/sockstat/sockstat_linux.go
+++ b/inputs/sockstat/sockstat_linux.go
@@ -1,0 +1,161 @@
+//go:build linux
+
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sockstat
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// ParseNetSockstat retrieves IPv4 socket statistics.
+func ParseNetSockstat() (*NetSockstat, error) {
+	return readSockstat("/proc/net/sockstat")
+}
+
+// ParseNetSockstat6 retrieves IPv6 socket statistics.
+//
+// If IPv6 is disabled on this kernel, the returned error can be checked with
+// os.IsNotExist.
+func ParseNetSockstat6() (*NetSockstat, error) {
+	return readSockstat("/proc/net/sockstat6")
+}
+
+// readSockstat opens and parses a NetSockstat from the input file.
+func readSockstat(name string) (*NetSockstat, error) {
+	// This file is small and can be read with one syscall.
+	b, err := ReadFileNoStat(name)
+	if err != nil {
+		// Do not wrap this error so the caller can detect os.IsNotExist and
+		// similar conditions.
+		return nil, err
+	}
+
+	stat, err := parseSockstat(bytes.NewReader(b))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read sockstats from %q: %w", name, err)
+	}
+
+	return stat, nil
+}
+
+// parseSockstat reads the contents of a sockstat file and parses a NetSockstat.
+func parseSockstat(r io.Reader) (*NetSockstat, error) {
+	var stat NetSockstat
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		// Expect a minimum of a protocol and one key/value pair.
+		fields := strings.Split(s.Text(), " ")
+		if len(fields) < 3 {
+			return nil, fmt.Errorf("malformed sockstat line: %q", s.Text())
+		}
+
+		// The remaining fields are key/value pairs.
+		kvs, err := parseSockstatKVs(fields[1:])
+		if err != nil {
+			return nil, fmt.Errorf("error parsing sockstat key/value pairs from %q: %w", s.Text(), err)
+		}
+
+		// The first field is the protocol. We must trim its colon suffix.
+		proto := strings.TrimSuffix(fields[0], ":")
+		switch proto {
+		case "sockets":
+			// Special case: IPv4 has a sockets "used" key/value pair that we
+			// embed at the top level of the structure.
+			used := kvs["used"]
+			stat.Used = &used
+		default:
+			// Parse all other lines as individual protocols.
+			nsp := parseSockstatProtocol(kvs)
+			nsp.Protocol = proto
+			stat.Protocols = append(stat.Protocols, nsp)
+		}
+	}
+
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+
+	return &stat, nil
+}
+
+// parseSockstatKVs parses a string slice into a map of key/value pairs.
+func parseSockstatKVs(kvs []string) (map[string]int, error) {
+	if len(kvs)%2 != 0 {
+		return nil, errors.New("odd number of fields in key/value pairs")
+	}
+
+	// Iterate two values at a time to gather key/value pairs.
+	out := make(map[string]int, len(kvs)/2)
+	for i := 0; i < len(kvs); i += 2 {
+		v, err := strconv.ParseInt(kvs[i+1], 0, 64)
+		if err != nil {
+			return nil, err
+		}
+		out[kvs[i]] = int(v)
+	}
+
+	return out, nil
+}
+
+// parseSockstatProtocol parses a NetSockstatProtocol from the input kvs map.
+func parseSockstatProtocol(kvs map[string]int) NetSockstatProtocol {
+	var nsp NetSockstatProtocol
+	for k, v := range kvs {
+		// Capture the range variable to ensure we get unique pointers for
+		// each of the optional fields.
+		v := v
+		switch k {
+		case "inuse":
+			nsp.InUse = v
+		case "orphan":
+			nsp.Orphan = &v
+		case "tw":
+			nsp.TW = &v
+		case "alloc":
+			nsp.Alloc = &v
+		case "mem":
+			nsp.Mem = &v
+		case "memory":
+			nsp.Memory = &v
+		}
+	}
+
+	return nsp
+}
+
+// ReadFileNoStat uses io.ReadAll to read contents of entire file.
+// This is similar to os.ReadFile but without the call to os.Stat, because
+// many files in /proc and /sys report incorrect file sizes (either 0 or 4096).
+// Reads a max file size of 1024kB.  For files larger than this, a scanner
+// should be used.
+func ReadFileNoStat(filename string) ([]byte, error) {
+	const maxBufferSize = 1024 * 1024
+
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	reader := io.LimitReader(f, maxBufferSize)
+	return io.ReadAll(reader)
+}

--- a/inputs/sockstat/sockstat_notlinux.go
+++ b/inputs/sockstat/sockstat_notlinux.go
@@ -1,0 +1,16 @@
+//go:build !linux
+
+package sockstat
+
+// ParseNetSockstat retrieves IPv4 socket statistics.
+func ParseNetSockstat() (*NetSockstat, error) {
+	return nil, nil
+}
+
+// ParseNetSockstat6 retrieves IPv6 socket statistics.
+//
+// If IPv6 is disabled on this kernel, the returned error can be checked with
+// os.IsNotExist.
+func ParseNetSockstat6() (*NetSockstat, error) {
+	return nil, nil
+}


### PR DESCRIPTION
1. 添加sockstat的插件，读取套接字状态
2. netstat插件添加connectionstats读取的开关，在机器链接数非常高时，可以选择手动关闭指标采集