### PR TITLE
fix: avoid panic when the instance is empty

### DIFF
--- a/inputs/oracle/oracle_linux_amd64.go
+++ b/inputs/oracle/oracle_linux_amd64.go
@@ -103,6 +103,9 @@ func (ins *Instance) Drop() error {
 }
 
 func (ins *Instance) Gather(slist *types.SampleList) {
+	if ins.client == nil {
+		return
+	}
 	tags := map[string]string{"address": ins.Address}
 
 	defer func(begun time.Time) {


### PR DESCRIPTION
fix: avoid panic when the instance is empty
![image](https://user-images.githubusercontent.com/38320121/229961857-41a79dd1-6c76-45e1-85df-77103832c0ec.png)
