### PR TITLE
procstat:push memory info for process

### DIFF
--- a/inputs/procstat/procstat.go
+++ b/inputs/procstat/procstat.go
@@ -324,6 +324,19 @@ func (ins *Instance) gatherMem(slist *types.SampleList, procs map[PID]Process, t
 				slist.PushFront(types.NewSample(inputName, "mem_usage", v, ins.makeProcTag(procs[pid]), tags))
 			}
 		}
+
+		minfo, err := procs[pid].MemoryInfo()
+		if err == nil {
+			if ins.GatherPerPid {
+				slist.PushFront(types.NewSample(inputName, "mem_rss", minfo.RSS, ins.makeProcTag(procs[pid]), tags))
+				slist.PushFront(types.NewSample(inputName, "mem_vms", minfo.VMS, ins.makeProcTag(procs[pid]), tags))
+				slist.PushFront(types.NewSample(inputName, "mem_hwm", minfo.HWM, ins.makeProcTag(procs[pid]), tags))
+				slist.PushFront(types.NewSample(inputName, "mem_data", minfo.Data, ins.makeProcTag(procs[pid]), tags))
+				slist.PushFront(types.NewSample(inputName, "mem_stack", minfo.Stack, ins.makeProcTag(procs[pid]), tags))
+				slist.PushFront(types.NewSample(inputName, "mem_locked", minfo.Locked, ins.makeProcTag(procs[pid]), tags))
+				slist.PushFront(types.NewSample(inputName, "mem_swap", minfo.Swap, ins.makeProcTag(procs[pid]), tags))
+			}
+		}
 	}
 
 	if ins.GatherTotal {


### PR DESCRIPTION
```
cat /proc/1778/status
```
<img width="474" alt="7D5FA4BD-A7E0-4DA1-B902-7FC572D8F242" src="https://user-images.githubusercontent.com/12164762/232993919-629b7d5b-c32c-4866-a9fd-e29f9f0db5a9.png">

```
top -p1778
```
<img width="900" alt="327AF74D-0129-46FC-9AA6-87D6C34EA801" src="https://user-images.githubusercontent.com/12164762/232994027-b16a834e-6e85-4706-85be-9926a00b3cdd.png">

```
categraf --test --inputs procstat
```
<img width="1572" alt="2F4D4BF0-0A83-4E1D-9476-957C8FDD22E8" src="https://user-images.githubusercontent.com/12164762/232994063-b8fee895-4ae0-4f58-b9d0-b03c678b9722.png">

rss vms与top对比
<img width="831" alt="18EBAAFA-AE1C-4582-9897-B5E635776931" src="https://user-images.githubusercontent.com/12164762/232994171-6328a8f0-7453-4615-b1ce-45308b0ef4cb.png">
