### PR TITLE
fix: fix panic when reload

### DIFF
--- a/agent/metrics_agent.go
+++ b/agent/metrics_agent.go
@@ -140,7 +140,7 @@ func (ma *MetricsAgent) Start() error {
 func (ma *MetricsAgent) Stop() error {
 	ma.InputProvider.StopReloader()
 	for name := range ma.InputReaders {
-		ma.InputReaders[name].Stop()
+		ma.DeregisterInput(name)
 	}
 	return nil
 }


### PR DESCRIPTION
fix: fix panic when reload

1、假设开启了3个插件，启动了程序，3个插件都有实例，运行正常
2、将其中1个插件例如http中的实例删除（配置文件保留），进行reload，此时按照原有逻辑，http这个插件会停止，但是并不会从ma.InputReaders中删除。 此时在reload的start的时候，因为http实例已经删除干净了，所以，不会再次生成 reader 
3、这时候将http这个插件补上一个实例，再次运行reload的时候，因为数组中http还在，所以将会对http这个组件再次执行stop，从而出现 panic: send on closed channel 