### PR TITLE
fix instances with nil client

### DIFF
--- a/agent/metrics_agent.go
+++ b/agent/metrics_agent.go
@@ -250,6 +250,7 @@ func (ma *MetricsAgent) inputGo(name string, sum checksum.Checksum, input inputs
 				continue
 			}
 			empty = false
+			instances[i].SetInitialized()
 		}
 
 		if empty {

--- a/agent/metrics_reader.go
+++ b/agent/metrics_reader.go
@@ -89,6 +89,9 @@ func (r *InputReader) gatherOnce() {
 	atomic.AddUint64(&r.runCounter, 1)
 
 	for i := 0; i < len(instances); i++ {
+		if !instances[i].Initialized() {
+			continue
+		}
 		r.waitGroup.Add(1)
 		go func(ins inputs.Instance) {
 			defer r.waitGroup.Done()

--- a/config/inline.go
+++ b/config/inline.go
@@ -31,6 +31,9 @@ type InternalConfig struct {
 
 	// mapping value
 	ProcessorEnum []*ProcessorEnum `toml:"processor_enum"`
+
+	// whether instance initial success
+	inited bool `toml:"-"`
 }
 
 func (ic *InternalConfig) GetLabels() map[string]string {
@@ -146,6 +149,14 @@ func (ic *InternalConfig) Process(slist *types.SampleList) *types.SampleList {
 	}
 
 	return nlst
+}
+
+func (ic *InternalConfig) Initialized() bool {
+	return ic.inited
+}
+
+func (ic *InternalConfig) SetInitialized() {
+	ic.inited = true
 }
 
 type PluginConfig struct {

--- a/go.mod
+++ b/go.mod
@@ -158,7 +158,7 @@ require (
 	github.com/census-instrumentation/opencensus-proto v0.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/cncf/xds/go v0.0.0-20220314180256-7f1daf1720fc // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.1
 	github.com/denisenkom/go-mssqldb v0.12.2
 	github.com/dennwc/varint v1.0.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect

--- a/inputs/inputs.go
+++ b/inputs/inputs.go
@@ -71,6 +71,9 @@ func Add(name string, creator Creator) {
 }
 
 type Instance interface {
+	Initialized() bool
+	SetInitialized()
+
 	GetLabels() map[string]string
 	GetIntervalTimes() int64
 	InitInternalConfig() error


### PR DESCRIPTION
1. 标记instance是否初始化成功
2. gather调用前会判断标记位，没初始化的不调用gather

场景：比如配置只有[[instances]]但是address为空，这样就没办法Init，就不会有一个client，但是gather方法中直接用了client.ping() , 像redis/mysql/oracle 插件。