### PR TITLE
refactor: output log to stdout when use test mode

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -173,6 +173,11 @@ func InitConfig(configDir string, debugMode, testMode bool, interval int64, inpu
 		Config.Ibex.MetaDir = "tasks.d"
 	}
 
+	// If using test mode, the logs are output to standard output for easy viewing
+	if testMode {
+		Config.Log.FileName = "stdout"
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
refactor: output log to stdout when use test mode

使用测试模式的时候，强制将日志输出到标准输出，方便测试（否则如果配置了日志，日志将会打印到日志文件，还得另开一个窗口去tail查看）