### PR TITLE
feature: 针对windows内存增加mem_free指标, 和linux处理逻辑保持一致

### DIFF
--- a/inputs/mem/mem.go
+++ b/inputs/mem/mem.go
@@ -55,6 +55,8 @@ func (s *MemStats) Gather(slist *types.SampleList) {
 
 	if s.CollectPlatformFields {
 		switch runtime.GOOS {
+		case "windows":
+			fields["free"] = vm.Free
 		case "darwin":
 			fields["active"] = vm.Active
 			fields["free"] = vm.Free


### PR DESCRIPTION
针对windows系统的指标输出增加mem_free 指标, 以便和linux处理逻辑保持一致

* 可以解决n9e内置“机器台账表格视图”无法正常显示windows“剩余内存”问题
* 方便配置统一的内存告警规则