### PR TITLE
添加 docker_container_health_status 容器健康检查状态

### DIFF
--- a/inputs/docker/docker.go
+++ b/inputs/docker/docker.go
@@ -322,6 +322,16 @@ func (ins *Instance) gatherContainerInspect(container types.Container, slist *it
 
 	if info.State.Health != nil {
 		slist.PushSample("docker_container", "health_failing_streak", info.ContainerJSONBase.State.Health.FailingStreak, tags)
+		var containerHealthStatesNum int
+		switch info.ContainerJSONBase.State.Health.Status {
+		case "healthy":
+			containerHealthStatesNum = 0
+		case "starting":
+			containerHealthStatesNum = 1
+		default:
+			containerHealthStatesNum = 2
+		}
+		slist.PushSample("docker_container", "health_status", containerHealthStatesNum, tags)
 	}
 
 	ins.parseContainerStats(v, slist, tags, daemonOSType)


### PR DESCRIPTION
input.docker 插件添加 docker_container_health_status 指标，检查 docker 容器健康检查状态。
* 指标为 0 时，healthy
* 指标为 1 时，starting
* 指标为 2 时，unhealthy