### PR TITLE
增加统计网络接收队列和发送队列值，多个链接结果加和

### DIFF
--- a/inputs/netstat_filter/README.md
+++ b/inputs/netstat_filter/README.md
@@ -1,4 +1,31 @@
 # netstat_filter
 
 该插件采集网络连接情况，并根据用户条件进行过滤统计，以达到监控用户关心链接情况
+## 指标列表
+tcp_established  
+tcp_syn_sent
+tcp_syn_recv
+tcp_fin_wait1
+tcp_fin_wait2
+tcp_time_wait
+tcp_close
+tcp_close_wait
+tcp_last_ack
+tcp_listen
+tcp_closing
+tcp_none
+tcp_send_queue
+tcp_recv_queue
 
+## 功能说明
+对源IP、源端口、目标IP和目标端口过滤后进行网卡recv-Q、send-Q进行采集，该指标可以很好反应出指定连接的质量，例如rtt时间过长，导致收到服务端ack确认很慢就会使send-Q长期大于0，可以及时通过监控发现，从而提前优化网络或程序
+
+当过滤结果为多个连接时会将send和recv值进行加和
+例如：
+配置文件``raddr_port = 11883``
+当本地和不同IP的11883都有连接建立的情况下，会将多条连接的结果进行加和。或在并发多连接的情况下，会合并加合，总之过滤的越粗略被加合数就会越多。
+
+多条规则请复制``[[instances]]``进行配置
+
+## 注意事项
+netstat_filter_tcp_send_queue和netstat_filter_tcp_recv_queue指标目前只支持linux。windows用户默认为0。

--- a/inputs/netstat_filter/entry.go
+++ b/inputs/netstat_filter/entry.go
@@ -1,0 +1,36 @@
+//go:build linux
+
+package netstat
+
+import "net"
+
+// Entry holds the information of a /proc/net/* entry.
+// For example, /proc/net/tcp:
+// sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+// 0:  0100007F:13AD 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 18083222
+type Entry struct {
+	Proto   string
+	SrcIP   net.IP
+	SrcPort uint
+	DstIP   net.IP
+	DstPort uint
+	Txq     uint
+	Rxq     uint
+	UserId  int
+	INode   int
+}
+
+// NewEntry creates a new entry with values from /proc/net/
+func NewEntry(proto string, srcIP net.IP, srcPort uint, dstIP net.IP, dstPort uint, txq uint, rxq uint, userId int, iNode int) Entry {
+	return Entry{
+		Proto:   proto,
+		SrcIP:   srcIP,
+		SrcPort: srcPort,
+		DstIP:   dstIP,
+		DstPort: dstPort,
+		Txq:     txq,
+		Rxq:     rxq,
+		UserId:  userId,
+		INode:   iNode,
+	}
+}

--- a/inputs/netstat_filter/entry.go
+++ b/inputs/netstat_filter/entry.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package netstat
 
 import "net"

--- a/inputs/netstat_filter/netstat_filter.go
+++ b/inputs/netstat_filter/netstat_filter.go
@@ -106,8 +106,17 @@ func (ins *Instance) Gather(slist *types.SampleList) {
 		}
 	}
 	Entries, _ := Parse("tcp")
+	var send, recv int
 	// 对连接信息进行过滤
-	send, recv := FilterEntries(Entries, ins.Laddr_IP, ins.Laddr_Port, ins.Raddr_IP, ins.Raddr_Port)
+	result := FilterEntries(Entries, ins.Laddr_IP, ins.Laddr_Port, ins.Raddr_IP, ins.Raddr_Port)
+	key := fmt.Sprintf("%s-%d-%s-%d", ins.Laddr_IP, ins.Laddr_Port, ins.Raddr_IP, ins.Raddr_Port)
+	value, ok := result[key]
+	if ok {
+		send = value.Txq
+		recv = value.Rxq
+	} else {
+		log.Println("E! Key not matched, TCP_ Send_ Queue, TCP_ Recv_Queue，  The queue value is 0")
+	}
 
 	fields := map[string]interface{}{
 		"tcp_established": counts["ESTABLISHED"],
@@ -122,8 +131,8 @@ func (ins *Instance) Gather(slist *types.SampleList) {
 		"tcp_listen":      counts["LISTEN"],
 		"tcp_closing":     counts["CLOSING"],
 		"tcp_none":        counts["NONE"],
-		"tcp_send_q":      send,
-		"tcp_recv_q":      recv,
+		"tcp_send_queue":  send,
+		"tcp_recv_queue":  recv,
 	}
 
 	slist.PushSamples(inputName, fields, tags)

--- a/inputs/netstat_filter/netstat_filter.go
+++ b/inputs/netstat_filter/netstat_filter.go
@@ -105,6 +105,9 @@ func (ins *Instance) Gather(slist *types.SampleList) {
 			counts[netcon.Status] = c + 1
 		}
 	}
+	Entries, _ := Parse("tcp")
+	// 对连接信息进行过滤
+	send, recv := FilterEntries(Entries, ins.Laddr_IP, ins.Laddr_Port, ins.Raddr_IP, ins.Raddr_Port)
 
 	fields := map[string]interface{}{
 		"tcp_established": counts["ESTABLISHED"],
@@ -119,6 +122,8 @@ func (ins *Instance) Gather(slist *types.SampleList) {
 		"tcp_listen":      counts["LISTEN"],
 		"tcp_closing":     counts["CLOSING"],
 		"tcp_none":        counts["NONE"],
+		"tcp_send_q":      send,
+		"tcp_recv_q":      recv,
 	}
 
 	slist.PushSamples(inputName, fields, tags)

--- a/inputs/netstat_filter/netstat_tcp.go
+++ b/inputs/netstat_filter/netstat_tcp.go
@@ -1,0 +1,134 @@
+//go:build linux
+
+package netstat
+
+import (
+	"bufio"
+	"encoding/binary"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	parser = regexp.MustCompile(`(?i)` +
+		`\d+:\s+` + // sl
+		`([a-f0-9]{8,32}):([a-f0-9]{4})\s+` + // local_address
+		`([a-f0-9]{8,32}):([a-f0-9]{4})\s+` + // rem_address
+		`([a-f0-9]{2})\s+` + // st
+		`([a-f0-9]{8}):([a-f0-9]{8})\s+` + // tx_queue rx_queue
+		`[a-f0-9]{2}:[a-f0-9]{8}\s+` + // tr tm->when
+		`[a-f0-9]{8}\s+` + // retrnsmt
+		`(\d+)\s+` + // uid
+		`\d+\s+` + // timeout
+		`(\d+)\s+` + // inode
+		`.+`) // stuff we don't care about
+)
+
+const (
+	defaultTrimSet = "\r\n\t "
+)
+
+// Trim remove trailing spaces from a string.
+func Trim(s string) string {
+	return strings.Trim(s, defaultTrimSet)
+}
+
+func decToInt(n string) int {
+	d, err := strconv.ParseInt(n, 10, 64)
+	if err != nil {
+		log.Printf("Error while parsing %s to int: %s", n, err)
+	}
+	return int(d)
+}
+
+func hexToInt(h string) uint {
+	d, err := strconv.ParseUint(h, 16, 64)
+	if err != nil {
+		log.Printf("Error while parsing %s to int: %s", h, err)
+	}
+	return uint(d)
+}
+
+func hexToInt2(h string) (uint, uint) {
+	if len(h) > 16 {
+		d, err := strconv.ParseUint(h[:16], 16, 64)
+		if err != nil {
+			log.Printf("Error while parsing %s to int: %s", h[16:], err)
+		}
+		d2, err := strconv.ParseUint(h[16:], 16, 64)
+		if err != nil {
+			log.Printf("Error while parsing %s to int: %s", h[16:], err)
+		}
+		return uint(d), uint(d2)
+	}
+
+	d, err := strconv.ParseUint(h, 16, 64)
+	if err != nil {
+		log.Printf("Error while parsing %s to int: %s", h[16:], err)
+	}
+	return uint(d), 0
+}
+
+func hexToIP(h string) net.IP {
+	n, m := hexToInt2(h)
+	var ip net.IP
+	if m != 0 {
+		ip = make(net.IP, 16)
+		// TODO: Check if this depends on machine endianness?
+		binary.LittleEndian.PutUint32(ip, uint32(n>>32))
+		binary.LittleEndian.PutUint32(ip[4:], uint32(n))
+		binary.LittleEndian.PutUint32(ip[8:], uint32(m>>32))
+		binary.LittleEndian.PutUint32(ip[12:], uint32(m))
+	} else {
+		ip = make(net.IP, 4)
+		binary.LittleEndian.PutUint32(ip, uint32(n))
+	}
+	return ip
+}
+
+// Parse scans and retrieves the opened connections, from /proc/net/ files
+func Parse(proto string) ([]Entry, error) {
+	filename := fmt.Sprintf("/proc/net/%s", proto)
+	fd, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer fd.Close()
+
+	entries := make([]Entry, 0)
+	scanner := bufio.NewScanner(fd)
+	for lineno := 0; scanner.Scan(); lineno++ {
+		// 跳过列名
+		if lineno == 0 {
+			continue
+		}
+
+		line := Trim(scanner.Text())
+		m := parser.FindStringSubmatch(line)
+		if m == nil {
+			log.Printf("Could not parse netstat line from %s: %s", filename, line)
+			continue
+		}
+		//只统计状态为TCP_ESTABLISHED
+		if m[5] == "01" {
+			entries = append(entries, NewEntry(
+				proto,
+				hexToIP(m[1]),
+				hexToInt(m[2]),
+				hexToIP(m[3]),
+				hexToInt(m[4]),
+				hexToInt(m[6]), // tx_queue发送
+				hexToInt(m[7]), // rx_queue接收
+				decToInt(m[8]), //uid
+				decToInt(m[9]), //inode
+			))
+		}
+	}
+
+	return entries, nil
+}

--- a/inputs/netstat_filter/netstat_tcp.go
+++ b/inputs/netstat_filter/netstat_tcp.go
@@ -1,4 +1,5 @@
 //go:build linux
+// +build linux
 
 package netstat
 

--- a/inputs/netstat_filter/netstat_tcp_filter.go
+++ b/inputs/netstat_filter/netstat_tcp_filter.go
@@ -1,21 +1,37 @@
 //go:build linux
+// +build linux
 
 package netstat
 
-import "net"
+import (
+	"fmt"
+	"net"
+)
 
-func FilterEntries(entries []Entry, srcIP string, srcPort uint32, dstIP string, dstPort uint32) (int, int) {
-	var totalTxq, totalRxq int
+func FilterEntries(entries []Entry, srcIP string, srcPort uint32, dstIP string, dstPort uint32) map[string]struct {
+	Txq int
+	Rxq int
+} {
+	result := make(map[string]struct {
+		Txq int
+		Rxq int
+	})
 
 	for _, entry := range entries {
 		// 判断源IP、源端口、目标IP和目标端口是否与传入参数匹配
-		if len(srcIP) == 0 || entry.SrcIP.Equal(net.ParseIP(srcIP)) && srcPort == 0 || entry.SrcPort == uint(srcPort) &&
-			len(dstIP) == 0 || entry.DstIP.Equal(net.ParseIP(dstIP)) && dstPort == 0 || entry.DstPort == uint(dstPort) {
-			totalTxq += int(entry.Txq) //发送结果和
-			totalRxq += int(entry.Rxq) //接收结果和
-
+		if (len(srcIP) == 0 || entry.SrcIP.Equal(net.ParseIP(srcIP))) &&
+			(srcPort == 0 || entry.SrcPort == uint(srcPort)) &&
+			(len(dstIP) == 0 || entry.DstIP.Equal(net.ParseIP(dstIP))) &&
+			(dstPort == 0 || entry.DstPort == uint(dstPort)) {
+			// 构建匹配条件的唯一键
+			key := fmt.Sprintf("%s-%d-%s-%d", srcIP, srcPort, dstIP, dstPort)
+			// 获取临时变量，对其字段进行修改
+			temp := result[key]
+			temp.Txq += int(entry.Txq)
+			temp.Rxq += int(entry.Rxq)
+			// 将修改后的临时变量重新赋值给 result[key]
+			result[key] = temp
 		}
 	}
-
-	return totalTxq, totalRxq
+	return result
 }

--- a/inputs/netstat_filter/netstat_tcp_filter.go
+++ b/inputs/netstat_filter/netstat_tcp_filter.go
@@ -1,0 +1,21 @@
+//go:build linux
+
+package netstat
+
+import "net"
+
+func FilterEntries(entries []Entry, srcIP string, srcPort uint32, dstIP string, dstPort uint32) (int, int) {
+	var totalTxq, totalRxq int
+
+	for _, entry := range entries {
+		// 判断源IP、源端口、目标IP和目标端口是否与传入参数匹配
+		if len(srcIP) == 0 || entry.SrcIP.Equal(net.ParseIP(srcIP)) && srcPort == 0 || entry.SrcPort == uint(srcPort) &&
+			len(dstIP) == 0 || entry.DstIP.Equal(net.ParseIP(dstIP)) && dstPort == 0 || entry.DstPort == uint(dstPort) {
+			totalTxq += int(entry.Txq) //发送结果和
+			totalRxq += int(entry.Rxq) //接收结果和
+
+		}
+	}
+
+	return totalTxq, totalRxq
+}

--- a/inputs/netstat_filter/netstat_tcp_filter_nolinux.go
+++ b/inputs/netstat_filter/netstat_tcp_filter_nolinux.go
@@ -1,0 +1,15 @@
+//go:build !linux
+// +build !linux
+
+package netstat
+
+func FilterEntries(entries []Entry, srcIP string, srcPort uint32, dstIP string, dstPort uint32) map[string]struct {
+	Txq int
+	Rxq int
+} {
+	result := make(map[string]struct {
+		Txq int
+		Rxq int
+	})
+	return result
+}

--- a/inputs/netstat_filter/netstat_tcp_nolinux.go
+++ b/inputs/netstat_filter/netstat_tcp_nolinux.go
@@ -1,0 +1,22 @@
+//go:build !linux
+// +build !linux
+
+package netstat
+
+func Parse(proto string) ([]Entry, error) {
+	entries := make([]Entry, 0)
+
+	entries = append(entries, NewEntry(
+		proto,
+		nil,
+		0,
+		nil,
+		0,
+		0,
+		0,
+		0,
+		0,
+	))
+
+	return entries, nil
+}


### PR DESCRIPTION
对源IP、源端口、目标IP和目标端口过滤后进行网卡recv-Q、send-Q进行采集，该指标可以很好反应出指定链接的质量，例如rtt时间过长，导致收到服务端ack确认很慢就会使send-Q长期大于0，可以及时通过监控发现，从而提前优化网络或程序。
netstat_filter_tcp_recv_q 的数值表示接收缓冲区中还没拷贝到应用层的数据大小
netstat_filter_tcp_send_q 的数值表示发送缓冲区中未被确认的数据大小


测试样例：
st为2代表TCP_SYN_SENT状态，不进行统计，只统计TCP_ESTABLISHED:1 
![企业微信截图_16885543191067](https://github.com/flashcatcloud/categraf/assets/38203792/8122faba-cc73-4a2f-a51e-bdcfc12c2e0e)

扫描结果：
![企业微信截图_16885542993763](https://github.com/flashcatcloud/categraf/assets/38203792/55bb91b7-9c3c-4c43-a07f-84777a306f4b)
