### PR TITLE
fix nginx: 指标名称重复

### DIFF
--- a/inputs/nginx/nginx.go
+++ b/inputs/nginx/nginx.go
@@ -180,18 +180,18 @@ func (ins *Instance) gather(addr *url.URL, slist *types.SampleList) error {
 	}(resp.Body)
 
 	fields := map[string]interface{}{
-		"nginx_up": 1,
+		"up": 1,
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		fields["nginx_up"] = 0
+		fields["up"] = 0
 		pushList(addr, slist, fields)
 		return fmt.Errorf("the HTTP response status exception, url: %s, status: %s", addr.String(), resp.Status)
 	}
 
 	err = parseResponseBody(resp.Body, fields)
 	if err != nil {
-		fields["nginx_up"] = 0
+		fields["up"] = 0
 	}
 	pushList(addr, slist, fields)
 	return err


### PR DESCRIPTION
slist.PushSamples(prefix string, fields map[string]interface{}, labels ...map[string]string)
推送的时候，已经带上inputName作为prefix参数了，就形成了 nginx_nginx_up的指标名