### PR TITLE
fix: check instance length

### DIFF
--- a/agent/metrics_agent.go
+++ b/agent/metrics_agent.go
@@ -266,7 +266,7 @@ func (ma *MetricsAgent) inputGo(name string, sum string, input inputs.Input) {
 	}
 
 	instances := inputs.MayGetInstances(input)
-	if instances != nil {
+	if len(instances) > 0 {
 		empty := true
 		for i := 0; i < len(instances); i++ {
 			if err := instances[i].InitInternalConfig(); err != nil {


### PR DESCRIPTION
if an input.GetInstances() return a slice with length 0, it will be dropped and never enter the gather loop,
but we still have input.Gather() to process in addition to instance.Gather()
https://github.com/flashcatcloud/categraf/blob/53338592a1b6528a9429e97ca7bc0ff27466dac8/agent/metrics_agent.go#L287-L293