### PR TITLE
docs:  disable CDFS by default

### DIFF
--- a/conf/input.disk/disk.toml
+++ b/conf/input.disk/disk.toml
@@ -6,6 +6,6 @@
 # mount_points = ["/"]
 
 # Ignore mount points by filesystem type.
-ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs", "nsfs"]
+ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs", "nsfs", "CDFS"]
 
 ignore_mount_points = ["/boot", "/var/lib/kubelet/pods"]


### PR DESCRIPTION
docs:  disable CDFS by default

发现在windows下，经常可能会有挂载cd驱动器的情况，一般使用率会读取为100%，不知道这是否是实际中一直存在的问题，大佬可以看下，默认禁用CDFS是否是最佳实践

![image](https://github.com/flashcatcloud/categraf/assets/38320121/45e48ff0-241b-49f7-ba70-addbc3e64f23)
