### PR TITLE
feat: extracting flow values from the rune array

### DIFF
--- a/inputs/snmp/table.go
+++ b/inputs/snmp/table.go
@@ -698,7 +698,7 @@ func fieldConvert(conv string, v interface{}) (interface{}, error) {
 		return v, nil
 	}
 
-	// 55 57 57 51 46 56 32 77 66   may be the ascii rune arr for string ->  7993.8 MB
+	// 55 57 57 51 46 56 32 77 66   may be the ascii arr for string ->  7993.8 MB
 	if conv == "asciitobytes" {
 
 		input, ok := v.([]uint8)
@@ -706,13 +706,8 @@ func fieldConvert(conv string, v interface{}) (interface{}, error) {
 			return nil, fmt.Errorf("invalid type of %v (not rune arr)", v)
 		}
 
-		// 将 []uint8 转换为字符切片
-		chars := make([]rune, len(input))
-		for i, val := range input {
-			chars[i] = rune(val)
-		}
-		// 将字符切片转换为字符串
-		asciiStr := string(chars)
+		// 将ascii字符切片转换为字符串
+		asciiStr := string(input)
 
 		// 提取数值
 		var numericStr string
@@ -737,14 +732,24 @@ func fieldConvert(conv string, v interface{}) (interface{}, error) {
 		case "B":
 			result = value
 		case "KB":
-			result = value * 1024
+			result = value * 1000
 		case "MB":
-			result = value * 1024 * 1024
+			result = value * 1000 * 1000
 		case "GB":
-			result = value * 1024 * 1024 * 1024
+			result = value * 1000 * 1000 * 1000
 		case "TB":
-			result = value * 1024 * 1024 * 1024 * 1024
+			result = value * 1000 * 1000 * 1000 * 1000
 		case "PB":
+			result = value * 1000 * 1000 * 1000 * 1000 * 1000
+		case "KIB":
+			result = value * 1024
+		case "MIB":
+			result = value * 1024 * 1024
+		case "GIB":
+			result = value * 1024 * 1024 * 1024
+		case "TIB":
+			result = value * 1024 * 1024 * 1024 * 1024
+		case "PIB":
 			result = value * 1024 * 1024 * 1024 * 1024 * 1024
 		default:
 			return nil, fmt.Errorf("invalid unit of %s", unit)

--- a/inputs/snmp/table.go
+++ b/inputs/snmp/table.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"flashcat.cloud/categraf/config"
 	"github.com/Knetic/govaluate"
 	"github.com/gosnmp/gosnmp"
 )
@@ -548,6 +549,10 @@ func fieldConvert(conv string, v interface{}) (interface{}, error) {
 		return v, nil
 	}
 
+	if config.Config.DebugMode {
+		log.Printf("D! %s the value %v", conv, v)
+	}
+
 	var d int
 	if _, err := fmt.Sscanf(conv, "float(%d)", &d); err == nil || conv == "float" {
 		switch vt := v.(type) {
@@ -691,6 +696,61 @@ func fieldConvert(conv string, v interface{}) (interface{}, error) {
 		}
 
 		return v, nil
+	}
+
+	// 55 57 57 51 46 56 32 77 66   may be the ascii rune arr for string ->  7993.8 MB
+	if conv == "asciitobytes" {
+
+		input, ok := v.([]uint8)
+		if !ok {
+			return nil, fmt.Errorf("invalid type of %v (not rune arr)", v)
+		}
+
+		// 将 []uint8 转换为字符切片
+		chars := make([]rune, len(input))
+		for i, val := range input {
+			chars[i] = rune(val)
+		}
+		// 将字符切片转换为字符串
+		asciiStr := string(chars)
+
+		// 提取数值
+		var numericStr string
+		for _, char := range asciiStr {
+			if char >= '0' && char <= '9' || char == '.' {
+				numericStr += string(char)
+			}
+		}
+
+		// 将字符串转换为浮点数
+		value, err := strconv.ParseFloat(numericStr, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid number part of %s", asciiStr)
+		}
+
+		// 解析单位并转换为字节数
+		unit := strings.ToUpper(strings.TrimSpace(strings.Trim(asciiStr, numericStr)))
+		var result float64
+		switch unit {
+		case "":
+			result = value
+		case "B":
+			result = value
+		case "KB":
+			result = value * 1024
+		case "MB":
+			result = value * 1024 * 1024
+		case "GB":
+			result = value * 1024 * 1024 * 1024
+		case "TB":
+			result = value * 1024 * 1024 * 1024 * 1024
+		case "PB":
+			result = value * 1024 * 1024 * 1024 * 1024 * 1024
+		default:
+			return nil, fmt.Errorf("invalid unit of %s", unit)
+		}
+
+		return result, nil
 	}
 
 	return nil, fmt.Errorf("invalid conversion type '%s'", conv)


### PR DESCRIPTION
feat: extracting flow values from the rune array

例如某些老机器，如老的深信服AC
获取sfSysTotalMemory 总内存：OID 1.3.6.1.4.1.35047.1.9  会返回 7993.8 MB

增加函数 asciitobytes 将从此字符串中提取数值并转换为字节数
55 57 57 51 46 56 32 77 66   may be the ascii rune arr for string ->  7993.8 MB
