### PR TITLE
fragmentation  mysql table

### DIFF
--- a/inputs/mysql/queries.go
+++ b/inputs/mysql/queries.go
@@ -38,14 +38,16 @@ GROUP BY table_schema`
 	SQL_QUERY_TABLE_SIZE = `
 SELECT   table_schema, table_name,
          IFNULL(index_length,0) AS index_size_bytes,
-         IFNULL(data_length,0) AS data_size_bytes
+         IFNULL(data_length,0) AS data_size_bytes,
+         IFNULL(data_free,0) AS data_free_size_bytes
 FROM     information_schema.tables
 WHERE    table_schema not in ('mysql', 'performance_schema', 'information_schema', 'sys')`
 
 	SQL_QUERY_SYSTEM_TABLE_SIZE = `
 SELECT   table_schema, table_name,
          IFNULL(index_length,0) AS index_size_bytes,
-         IFNULL(data_length,0) AS data_size_bytes
+         IFNULL(data_length,0) AS data_size_bytes,
+         IFNULL(data_free,0) AS data_free_size_bytes
 FROM     information_schema.tables
 WHERE    table_schema in ('mysql', 'performance_schema', 'information_schema', 'sys')`
 

--- a/inputs/mysql/table_size.go
+++ b/inputs/mysql/table_size.go
@@ -33,9 +33,9 @@ func (ins *Instance) gatherTableSize(slist *types.SampleList, db *sql.DB, global
 
 	for rows.Next() {
 		var schema, table string
-		var indexSize, dataSize int64
+		var indexSize, dataSize, dataFree int64
 
-		err = rows.Scan(&schema, &table, &indexSize, &dataSize)
+		err = rows.Scan(&schema, &table, &indexSize, &dataSize, &dataFree)
 		if err != nil {
 			log.Println("E! failed to scan rows:", err)
 			return
@@ -43,5 +43,6 @@ func (ins *Instance) gatherTableSize(slist *types.SampleList, db *sql.DB, global
 
 		slist.PushFront(types.NewSample(inputName, "table_size_index_bytes", indexSize, labels, map[string]string{"schema": schema, "table": table}))
 		slist.PushFront(types.NewSample(inputName, "table_size_data_bytes", dataSize, labels, map[string]string{"schema": schema, "table": table}))
+		slist.PushFront(types.NewSample(inputName, "table_size_free_data_bytes", dataFree, labels, map[string]string{"schema": schema, "table": table}))
 	}
 }


### PR DESCRIPTION
Add the fragmentation rate of mysql table. This data is because the space cannot be reclaimed by the system after delete, so you need to optimize the table.