### PR TITLE
fix:headers concurrent map writes and add dial remote addr

### DIFF
--- a/conf/input.http_response/http_response.toml
+++ b/conf/input.http_response/http_response.toml
@@ -8,8 +8,8 @@
 
 [[instances]]
 targets = [
-#     "http://localhost",
-#     "https://www.baidu.com"
+    #     "http://localhost",
+    #     "https://www.baidu.com"
 ]
 
 ## append some labels for series
@@ -18,8 +18,7 @@ targets = [
 ## interval = global.interval * interval_times
 # interval_times = 1
 
-## Set http_proxy (categraf uses the system wide proxy settings if it's is not set)
-# http_proxy = "http://localhost:8888"
+
 
 ## Interface to use when dialing an address
 # interface = "eth0"
@@ -38,7 +37,7 @@ targets = [
 # password = "pa$$word"
 
 ## Optional headers
-# headers = ["Header-Key-1", "Header-Value-1", "Header-Key-2", "Header-Value-2"]
+# headers = { "Accept-Encoding" = "Gzip" }
 
 ## Optional HTTP Request Body
 # body = '''
@@ -56,10 +55,16 @@ targets = [
 # expect_response_status_code = 0
 # expect_response_status_codes = "200|301"
 
+## Set http conn remote addr
+# http_remote_addr = "10.10.10.10:80"
+
 ## Optional TLS Config
-# use_tls = false
+# use_tls = true
+## Set https conn remote addr(required use_tls)
+# tls_remote_addr = "10.10.10.10:443"
 # tls_ca = "/etc/categraf/ca.pem"
 # tls_cert = "/etc/categraf/cert.pem"
 # tls_key = "/etc/categraf/key.pem"
+# tls_server_name = "www.baidu.com"
 ## Use TLS but skip chain & host verification
 # insecure_skip_verify = false

--- a/pkg/httpx/client.go
+++ b/pkg/httpx/client.go
@@ -8,7 +8,6 @@ package httpx
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"log"
 	"net"
 	"net/http"
@@ -122,7 +121,6 @@ func SetTransportRemoteAddr(remoteAddr string) Option {
 				if err != nil {
 					return nil, err
 				}
-				fmt.Println(conn.RemoteAddr(), conn.LocalAddr())
 				return conn, nil
 			}
 		}

--- a/pkg/httpx/client.go
+++ b/pkg/httpx/client.go
@@ -6,7 +6,9 @@
 package httpx
 
 import (
+	"context"
 	"crypto/tls"
+	"fmt"
 	"log"
 	"net"
 	"net/http"
@@ -109,6 +111,43 @@ func FollowRedirects(followRedirects bool) Option {
 func DisableKeepAlives(disableKeepAlives bool) Option {
 	return func(client *http.Client) {
 		client.Transport.(*http.Transport).DisableKeepAlives = disableKeepAlives
+	}
+}
+func SetTransportRemoteAddr(remoteAddr string) Option {
+	return func(client *http.Client) {
+		if len(remoteAddr) > 0 {
+			client.Transport.(*http.Transport).DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+				conn, err := net.Dial(network, remoteAddr)
+				//conn, err := client.Transport.(*http.Transport).DialContext(ctx, network, remoteAddr)
+				if err != nil {
+					return nil, err
+				}
+				fmt.Println(conn.RemoteAddr(), conn.LocalAddr())
+				return conn, nil
+			}
+		}
+	}
+}
+
+func SetTransportTlsRemoteAddr(remoteAddr string, tlsConfig *tls.Config) Option {
+	return func(client *http.Client) {
+		if len(remoteAddr) > 0 && tlsConfig != nil {
+			client.Transport.(*http.Transport).DialTLSContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+				conn, err := client.Transport.(*http.Transport).DialContext(ctx, network, remoteAddr)
+				if err != nil {
+					return nil, err
+				}
+
+				// 建立 TLS 连接
+				tlsConn := tls.Client(conn, tlsConfig)
+				if err := tlsConn.Handshake(); err != nil {
+					conn.Close()
+					return nil, err
+				}
+
+				return tlsConn, nil
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
![image](https://github.com/flashcatcloud/categraf/assets/16916249/eb6fb2c0-61e2-45b5-92a3-ae3510669708)
1. headers没有必要重新定义,有map并发写问题
2. 添加了http和https 建联ip指定的功能代替原生的proxy,解决https指定代理无法访问的问题