### PR TITLE
fix: metrics lost when net interface has invalid speed

### DIFF
--- a/inputs/net/net.go
+++ b/inputs/net/net.go
@@ -99,13 +99,6 @@ func (s *NetIOStats) Gather(slist *types.SampleList) {
 		if iface.Flags&net.FlagUp == 0 {
 			continue
 		}
-		speed, err := Speed(iface.Name)
-		if err != nil {
-			continue
-		}
-		if speed < 0 {
-			continue
-		}
 		tags := map[string]string{
 			"interface": io.Name,
 		}
@@ -121,7 +114,12 @@ func (s *NetIOStats) Gather(slist *types.SampleList) {
 			"err_out":      io.Errout,
 			"drop_in":      io.Dropin,
 			"drop_out":     io.Dropout,
-			"speed":        speed,
+		}
+		speed, err := Speed(iface.Name)
+		if err == nil && speed >= 0 {
+			fields["speed"] = speed
+		} else {
+			fields["speed"] = -2
 		}
 
 		slist.PushSamples(inputName, fields, tags)


### PR DESCRIPTION
<img width="755" alt="image" src="https://github.com/flashcatcloud/categraf/assets/12164762/e5c2478b-a350-4812-91f2-21b678c2240d">

/sys/class/net/<iface>/speed 返回error或者负值时，整个interface的指标都被丢起了