### PR TITLE
feat: pushgateway api support url labels

### DIFF
--- a/api/router_func.go
+++ b/api/router_func.go
@@ -26,6 +26,17 @@ func readerGzipBody(contentEncoding string, request *http.Request) (bytes []byte
 
 		defer r.Close()
 		bytes, err = ioutil.ReadAll(r)
+	} else if contentEncoding == "snappy" {
+		defer request.Body.Close()
+		compressed, err := ioutil.ReadAll(request.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		bytes, err = snappy.Decode(nil, compressed)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		defer request.Body.Close()
 		bytes, err = ioutil.ReadAll(request.Body)

--- a/api/router_func.go
+++ b/api/router_func.go
@@ -34,9 +34,6 @@ func readerGzipBody(contentEncoding string, request *http.Request) (bytes []byte
 		}
 
 		bytes, err = snappy.Decode(nil, compressed)
-		if err != nil {
-			return nil, err
-		}
 	} else {
 		defer request.Body.Close()
 		bytes, err = ioutil.ReadAll(request.Body)

--- a/api/router_pushgateway.go
+++ b/api/router_pushgateway.go
@@ -1,7 +1,11 @@
 package api
 
 import (
+	"encoding/base64"
+	"fmt"
+	"github.com/prometheus/common/model"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -12,16 +16,42 @@ import (
 	"flashcat.cloud/categraf/writer"
 )
 
+const (
+	// Base64Suffix is appended to a label name in the request URL path to
+	// mark the following label value as base64 encoded.
+	Base64Suffix = "@base64"
+)
+
 func pushgateway(c *gin.Context) {
 	var (
-		err error
-		bs  []byte
+		err    error
+		bs     []byte
+		labels map[string]string
 	)
 
 	bs, err = readerGzipBody(c.GetHeader("Content-Encoding"), c.Request)
 	if err != nil {
 		c.String(http.StatusBadRequest, err.Error())
 		return
+	}
+
+	// jobtype {"", "job", "job@base64"}
+	jobType := c.Param("jobtype")
+	job := c.Param("job")
+	if jobType == "job"+Base64Suffix {
+		var err error
+		if job, err = decodeBase64(job); err != nil {
+			c.String(http.StatusBadRequest, "invalid base64 encoding in job name %q: %v", job, err)
+			return
+		}
+	}
+	labelsString := c.Param("labels")
+	if labels, err = splitLabels(labelsString); err != nil {
+		c.String(http.StatusBadRequest, err.Error())
+		return
+	}
+	if job != "" {
+		labels["job"] = job
 	}
 
 	parser := prometheus.EmptyParser()
@@ -59,6 +89,11 @@ func pushgateway(c *gin.Context) {
 			}
 		}
 
+		// add url labels
+		for k, v := range labels {
+			samples[i].Labels[k] = v
+		}
+
 		// add label: agent_hostname
 		if _, has := samples[i].Labels[agentHostnameLabelKey]; !has && !ignoreHostname {
 			samples[i].Labels[agentHostnameLabelKey] = config.Config.GetHostname()
@@ -67,4 +102,45 @@ func pushgateway(c *gin.Context) {
 	}
 	writer.WriteSamples(samples)
 	c.String(200, "forwarding...")
+}
+
+// fork prometheus/pushgateway handler/push.go
+
+// decodeBase64 decodes the provided string using the “Base 64 Encoding with URL
+// and Filename Safe Alphabet” (RFC 4648). Padding characters (i.e. trailing
+// '=') are ignored.
+func decodeBase64(s string) (string, error) {
+	b, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(s, "="))
+	return string(b), err
+}
+
+// splitLabels splits a labels string into a label map mapping names to values.
+func splitLabels(labels string) (map[string]string, error) {
+	result := map[string]string{}
+	if len(labels) <= 1 {
+		return result, nil
+	}
+	components := strings.Split(labels[1:], "/")
+	if len(components)%2 != 0 {
+		return nil, fmt.Errorf("odd number of components in label string %q", labels)
+	}
+
+	for i := 0; i < len(components)-1; i += 2 {
+		name, value := components[i], components[i+1]
+		trimmedName := strings.TrimSuffix(name, Base64Suffix)
+		if !model.LabelNameRE.MatchString(trimmedName) ||
+			strings.HasPrefix(trimmedName, model.ReservedLabelPrefix) {
+			return nil, fmt.Errorf("improper label name %q", trimmedName)
+		}
+		if name == trimmedName {
+			result[name] = value
+			continue
+		}
+		decodedValue, err := decodeBase64(value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid base64 encoding for label %s=%q: %v", trimmedName, value, err)
+		}
+		result[trimmedName] = decodedValue
+	}
+	return result, nil
 }

--- a/api/router_pushgateway.go
+++ b/api/router_pushgateway.go
@@ -3,12 +3,12 @@ package api
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/prometheus/common/model"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/common/model"
 
 	"flashcat.cloud/categraf/config"
 	"flashcat.cloud/categraf/parser/prometheus"

--- a/api/server.go
+++ b/api/server.go
@@ -73,5 +73,11 @@ func configRoutes(r *gin.Engine) {
 	g.POST("/opentsdb", openTSDB)
 	g.POST("/openfalcon", openFalcon)
 	g.POST("/remotewrite", remoteWrite)
+
+	// pushgateway
 	g.POST("/pushgateway", pushgateway)
+	g.PUT("/pushgateway/metrics/:jobtype/:job", pushgateway)
+	g.POST("/pushgateway/metrics/:jobtype/:job", pushgateway)
+	g.PUT("/pushgateway/metrics/:jobtype/:job/*labels", pushgateway)
+	g.POST("/pushgateway/metrics/:jobtype/:job/*labels", pushgateway)
 }


### PR DESCRIPTION
- support standard [pushgateway http api](https://github.com/prometheus/pushgateway/tree/v1.8.0#api) on write. 
  > POST PUT    /api/push/pushgateway/metrics/job/<JOB_NAME>{/<LABEL_NAME>/<LABEL_VALUE>}
- add snappy compress on pushgateway.