### PR TITLE
Support Vars $sn for Config

### DIFF
--- a/conf/config.toml
+++ b/conf/config.toml
@@ -7,6 +7,7 @@ print_configs = false
 # "xx" -> use specified string xx
 # "$hostname" -> auto detect hostname
 # "$ip" -> auto detect ip
+# "$sn" -> auto detect bios serial number
 # "$hostname-$ip" -> auto detect hostname and ip to replace the vars
 hostname = ""
 
@@ -30,6 +31,7 @@ concurrency = -1
 [global.labels]
 # region = "shanghai"
 # env = "localhost"
+# sn = "$sn"
 
 [log]
 # file_name is the file to write logs to


### PR DESCRIPTION
配置文件支持使用sn变量来表示Bios Serial Number。可用于主机名和全局变量。