### PR TITLE
fix: Check getPythonVersion Result Empty

### DIFF
--- a/heartbeat/platform/platform_common.go
+++ b/heartbeat/platform/platform_common.go
@@ -66,6 +66,9 @@ func getPythonVersion() (string, error) {
 		return "", err
 	}
 	version := fmt.Sprintf("%s", out)
+	if version == "" {
+		return "", fmt.Errorf("python -V returned empty string")
+	}
 	values := regexp.MustCompile("Python (.*)\n").FindStringSubmatch(version)
 	return strings.Trim(values[1], "\r"), nil
 }


### PR DESCRIPTION
Check getPythonVersion Result Empty to Fix [window下程序异常退出](https://github.com/flashcatcloud/categraf/issues/928#issue-2294304761)