### PR TITLE
chore: Readd InfluxData to the copyright line of license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 The MIT License (MIT)
 
+Copyright (c) 2015-2024 InfluxData Inc.
 Copyright (c) 2022-now Flashcat Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Hi,

I am one of the Telegraf maintainers. It is really exciting to see that you been able to re-use much of Telegraf in this project! 

As this project is a fork of many of the Telegraf code base, it is important to maintain the copyright notice and the license itself. That way you stay compliant with the MIT license which requests:

> The above copyright notice and this permission notice shall be included in all
copies or substantial portions of the Software.

This PR re-adds the InfluxData copyright notice to the existing license.

Thanks!