### PR TITLE
add: input.disk ignore JuiceFS by default

### DIFF
--- a/conf/input.disk/disk.toml
+++ b/conf/input.disk/disk.toml
@@ -6,6 +6,6 @@
 # mount_points = ["/"]
 
 # Ignore mount points by filesystem type.
-ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs", "nsfs", "CDFS"]
+ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs", "nsfs", "CDFS","JuiceFS"]
 
 ignore_mount_points = ["/boot", "/var/lib/kubelet/pods"]


### PR DESCRIPTION
If not ignored, it will cause categraf to request a large amount of memory when starting up, leading to an OOM (Out Of Memory) error.

what is juicefs ? click https://juicefs.com/