### PR TITLE
fix: input.disk juicefs type

### DIFF
--- a/conf/input.disk/disk.toml
+++ b/conf/input.disk/disk.toml
@@ -6,6 +6,6 @@
 # mount_points = ["/"]
 
 # Ignore mount points by filesystem type.
-ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs", "nsfs", "CDFS","JuiceFS"]
+ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs", "nsfs", "CDFS", "fuse.juicefs"]
 
 ignore_mount_points = ["/boot", "/var/lib/kubelet/pods"]


### PR DESCRIPTION
Sorry, I got the wrong file type in the previous PR.
Please let me fix it, thanks.I've tested it, it must be right this time.

```
#df -hT
JuiceFS:juicenas fuse.juicefs  1.0P   12T 1013T   2% /mnt/juicenas
```

```
metrics:
{device="JuiceFS:juicenas",fstype="fuse.juicefs",ident="juice-nas",mode="rw",path="/mnt/juicenas"}
```