### PR TITLE
add pod ip in the log tags

### DIFF
--- a/logs/input/kubernetes/launcher.go
+++ b/logs/input/kubernetes/launcher.go
@@ -297,6 +297,7 @@ func buildTags(pod *kubernetes.Pod, container kubernetes.ContainerStatus) []stri
 		fmt.Sprintf("kubernetes.pod_id=%s", pod.Metadata.UID),
 		fmt.Sprintf("kubernetes.pod_name=%s", pod.Metadata.Name),
 		fmt.Sprintf("kubernetes.host=%s", pod.Spec.NodeName),
+		fmt.Sprintf("kubernetes.pod_ip=%s", pod.Status.PodIP),
 		fmt.Sprintf("kubernetes.container_id=%s", container.ID),
 		fmt.Sprintf("kubernetes.container_name=%s", container.Name),
 		fmt.Sprintf("kubernetes.container_image=%s", container.Image),


### PR DESCRIPTION
我们在调查问题的时候，比如哪个pod 访问我的应用的时候需要知道ip。因为访问记录都是记录ip地址。IP查询最直接。