### PR TITLE
typo: 修复一些链接或文档的错漏

### DIFF
--- a/conf/input.clickhouse/clickhouse.toml
+++ b/conf/input.clickhouse/clickhouse.toml
@@ -59,9 +59,9 @@
   # cluster_exclude = []
 
   ## Optional TLS Config
-  # tls_ca = "/etc/telegraf/ca.pem"
-  # tls_cert = "/etc/telegraf/cert.pem"
-  # tls_key = "/etc/telegraf/key.pem"
+  # tls_ca = "/etc/categraf/ca.pem"
+  # tls_cert = "/etc/categraf/cert.pem"
+  # tls_key = "/etc/categraf/key.pem"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
 

--- a/conf/input.consul/consul.toml
+++ b/conf/input.consul/consul.toml
@@ -34,8 +34,8 @@
   # kv_filter = ".*"
 
   ## Optional TLS Config
-  # tls_ca = "/etc/telegraf/ca.pem"
-  # tls_cert = "/etc/telegraf/cert.pem"
-  # tls_key = "/etc/telegraf/key.pem"
+  # tls_ca = "/etc/categraf/ca.pem"
+  # tls_cert = "/etc/categraf/cert.pem"
+  # tls_key = "/etc/categraf/key.pem"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = true

--- a/conf/input.docker/docker.toml
+++ b/conf/input.docker/docker.toml
@@ -57,8 +57,8 @@ docker_label_exclude = ["annotation*", "io.kubernetes*", "*description*", "*main
 
 ## Optional TLS Config
 # use_tls = false
-# tls_ca = "/etc/telegraf/ca.pem"
-# tls_cert = "/etc/telegraf/cert.pem"
-# tls_key = "/etc/telegraf/key.pem"
+# tls_ca = "/etc/categraf/ca.pem"
+# tls_cert = "/etc/categraf/cert.pem"
+# tls_key = "/etc/categraf/key.pem"
 ## Use TLS but skip chain & host verification
 # insecure_skip_verify = false

--- a/conf/input.influxdb/influxdb.toml
+++ b/conf/input.influxdb/influxdb.toml
@@ -11,9 +11,9 @@ urls = [
 # password = ""
 
 ## Optional TLS Config
-# tls_ca = "/etc/telegraf/ca.pem"
-# tls_cert = "/etc/telegraf/cert.pem"
-# tls_key = "/etc/telegraf/key.pem"
+# tls_ca = "/etc/categraf/ca.pem"
+# tls_cert = "/etc/categraf/cert.pem"
+# tls_key = "/etc/categraf/key.pem"
 ## Use TLS but skip chain & host verification
 # insecure_skip_verify = false
 

--- a/inputs/clickhouse/README.md
+++ b/inputs/clickhouse/README.md
@@ -74,9 +74,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # cluster_exclude = []
 
   ## Optional TLS Config
-  # tls_ca = "/etc/telegraf/ca.pem"
-  # tls_cert = "/etc/telegraf/cert.pem"
-  # tls_key = "/etc/telegraf/key.pem"
+  # tls_ca = "/etc/categraf/ca.pem"
+  # tls_cert = "/etc/categraf/cert.pem"
+  # tls_key = "/etc/categraf/key.pem"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
 

--- a/inputs/conntrack/README.md
+++ b/inputs/conntrack/README.md
@@ -1,6 +1,6 @@
 # conntrack
 
-运维老鸟应该会遇到 conntrack table full 的报错吧，这个插件就是用于监控 conntrack 的情况，forked from `telegraf/conntrack`
+运维老鸟应该会遇到 conntrack table full 的报错吧，这个插件就是用于监控 conntrack 的情况， forked from [telegraf/conntrack](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/conntrack)
 
 ## Measurements & Fields
 

--- a/inputs/docker/README.md
+++ b/inputs/docker/README.md
@@ -1,6 +1,7 @@
 # docker
 
-forked from telegraf/inputs.docker
+forked from [telegraf/inputs.docker](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/docker)
+
 
 ## change
 

--- a/inputs/filecount/README.md
+++ b/inputs/filecount/README.md
@@ -1,6 +1,6 @@
 # Filecount Input Plugin
 
-forked from telegraf/inputs.filecount
+forked from [telegraf/inputs.filecount](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/filecount)
 
 Reports the number and total size of files in specified directories.
 

--- a/inputs/influxdb/README.md
+++ b/inputs/influxdb/README.md
@@ -383,7 +383,7 @@ built from the InfluxDB source, and may vary between versions:
 ## Example Output
 
 ```sh
-categraf --config ~/ws/categraf.conf --input-filter influxdb --test
+categraf --configs /path/to/conf-directory --inputs influxdb --test
 * Plugin: influxdb, Collection 1
 > influxdb_database,database=_internal,host=tyrion,url=http://localhost:8086/debug/vars numMeasurements=10,numSeries=29 1463590500247354636
 > influxdb_httpd,bind=:8086,host=tyrion,url=http://localhost:8086/debug/vars req=7,reqActive=1,reqDurationNs=14227734 1463590500247354636

--- a/inputs/influxdb/README.md
+++ b/inputs/influxdb/README.md
@@ -28,9 +28,9 @@ InfluxDB-formatted endpoints. See below for more information.
   # password = ""
 
   ## Optional TLS Config
-  # tls_ca = "/etc/telegraf/ca.pem"
-  # tls_cert = "/etc/telegraf/cert.pem"
-  # tls_key = "/etc/telegraf/key.pem"
+  # tls_ca = "/etc/categraf/ca.pem"
+  # tls_cert = "/etc/categraf/cert.pem"
+  # tls_key = "/etc/categraf/key.pem"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
 
@@ -383,7 +383,7 @@ built from the InfluxDB source, and may vary between versions:
 ## Example Output
 
 ```sh
-telegraf --config ~/ws/telegraf.conf --input-filter influxdb --test
+categraf --config ~/ws/categraf.conf --input-filter influxdb --test
 * Plugin: influxdb, Collection 1
 > influxdb_database,database=_internal,host=tyrion,url=http://localhost:8086/debug/vars numMeasurements=10,numSeries=29 1463590500247354636
 > influxdb_httpd,bind=:8086,host=tyrion,url=http://localhost:8086/debug/vars req=7,reqActive=1,reqDurationNs=14227734 1463590500247354636

--- a/inputs/ipvs/README.md
+++ b/inputs/ipvs/README.md
@@ -1,7 +1,6 @@
 # ipvs
 
-Forked from telegraf. The IPVS input plugin uses the linux kernel netlink socket interface to gather
-metrics about ipvs virtual and real servers.
+Forked from [telegraf/ipvs](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/ipvs). The IPVS input plugin uses the linux kernel netlink socket interface to gather metrics about ipvs virtual and real servers.
 **Supported Platforms:** Linux
 
 ### Permissions

--- a/inputs/kafka/README.md
+++ b/inputs/kafka/README.md
@@ -1,6 +1,6 @@
 # kafka
 
-kafka 监控采集插件，由kafka-exporter（https://github.com/davidmparrott/kafka_exporter）封装而来。
+kafka 监控采集插件，由 [kafka-exporter](https://github.com/davidmparrott/kafka_exporter) 封装而来。
 
 ## Configuration
 
@@ -12,17 +12,17 @@ kafka 监控采集插件，由kafka-exporter（https://github.com/davidmparrott/
 
 
 ## 开源kafka-exporter 兼容说明
-categraf的exporter 封装 https://github.com/davidmparrott/kafka_exporter  (以下简称davidmparrott版本)  
+categraf的exporter 封装 https://github.com/davidmparrott/kafka_exporter  (以下简称davidmparrott版本)
 davidmparrott版本  fork自 https://github.com/danielqsj/kafka_exporter   (以下简称danielqsj版本)
 
 
 
-danielqsj版本作为原始版本, github版本也相对活跃, prometheus生态使用较多  
+danielqsj版本作为原始版本, github版本也相对活跃, prometheus生态使用较多
 categraf kafka plugin基于davidmparrott版本, 以下配置可以对danielqsj版本做一些兼容
 
-1. 增加metric: kafka_broker_info  
+1. 增加metric: kafka_broker_info
    davidmparrott版本无此metric, 默认以增加, 无需配置
-2. davidmparrott版本与danielqsj版本, 有以下metric名字不同:  
+2. davidmparrott版本与danielqsj版本, 有以下metric名字不同:
    | davidmparrott版本  | danielqsj版本 |
    | ---- | ---- |
    | kafka_consumergroup_uncommit_offsets  | kafka_consumergroup_lag |
@@ -34,7 +34,7 @@ categraf kafka plugin基于davidmparrott版本, 以下配置可以对danielqsj�
 rename_uncommit_offset_to_lag = true
 ```
 
-3. davidmparrott版本 比 danielqsj版本多以下metric  
+3. davidmparrott版本 比 danielqsj版本多以下metric
    以下metric是对延迟速率进行了计算
 
 - kafka_consumer_lag_millis

--- a/inputs/kubernetes/README.md
+++ b/inputs/kubernetes/README.md
@@ -1,6 +1,6 @@
 # kubernetes
 
-forked from telegraf/kubernetes. 这个插件的作用是通过kubelet提供的API获取监控数据，包括系统容器的监控数据、node的、pod数据卷的、pod网络的、pod容器的
+forked from [telegraf/kubernetes](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/kubernetes). 这个插件的作用是通过kubelet提供的API获取监控数据，包括系统容器的监控数据、node的、pod数据卷的、pod网络的、pod容器的
 
 ## Change
 

--- a/inputs/mongodb/README.md
+++ b/inputs/mongodb/README.md
@@ -1,11 +1,11 @@
 # mongodb
 
-mongodb 监控采集插件，由mongodb-exporter（https://github.com/percona/mongodb_exporter） 封装而来。v0.3.30-v0.3.42从telegraf/mongodb fork。
+mongodb 监控采集插件，由mongodb-exporter（https://github.com/percona/mongodb_exporter） 封装而来。v0.3.30-v0.3.42从 [telegraf/mongodb](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/mongodb) fork。
 
 ## Configuration
 
 
-    
+
 - 配置文件，[参考示例](../../conf/input.mongodb/mongodb.toml)
 - 配置权限，至少授予以下权限给配置文件中用于连接 MongoDB 的 user 才能收集指标：
     ```

--- a/inputs/nginx/README.md
+++ b/inputs/nginx/README.md
@@ -1,4 +1,4 @@
-- 该插件依赖**nginx**的 **http_stub_status_module
+- 该插件依赖 **nginx** 的 **http_stub_status_module**
 
 # 应用场景
 一般用于业务系统做对外或对外路由映射时使用代理服务，是运维最常见且最重要的代理工具。
@@ -93,7 +93,7 @@ server {
 }
 
 浏览器访问https://nginx.domains.com出现：
-Active connections: 5 
+Active connections: 5
 server accepts handled requests
  90837 90837   79582
 Reading: 0 Writing: 1 Waiting: 4

--- a/inputs/prometheus/README.md
+++ b/inputs/prometheus/README.md
@@ -2,7 +2,7 @@
 
 prometheus 插件的作用，就是抓取 `/metrics` 接口的数据，上报给服务端。通过，各类 exporter 会暴露 `/metrics` 接口数据，越来越多的开源组件也会内置 prometheus SDK，吐出 prometheus 格式的监控数据，比如 rabbitmq 插件，其 README 中就有介绍。
 
-这个插件 fork 自 telegraf/prometheus，做了一些删减改造，仍然支持通过 consul 做服务发现，管理所有的目标地址，删掉了 Kubernetes 部分，Kubernetes 部分准备放到其他插件里实现。
+这个插件 fork 自 [telegraf/prometheus](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/prometheus)，做了一些删减改造，仍然支持通过 consul 做服务发现，管理所有的目标地址，删掉了 Kubernetes 部分，Kubernetes 部分准备放到其他插件里实现。
 
 增加了两个配置：url_label_key 和 url_label_value。为了标识监控数据是从哪个 scrape url 拉取的，会为监控数据附一个标签来标识这个 url，默认的标签 KEY 是用 instance，当然，也可以改成别的，不过不建议。url_label_value 是标签值，支持 go template 语法，如果为空，就是整个 url 的内容，也可以通过模板变量只取一部分，比如 `http://localhost:9104/metrics`，只想取 IP 和端口部分，就可以写成：
 

--- a/inputs/rabbitmq/README.md
+++ b/inputs/rabbitmq/README.md
@@ -1,6 +1,6 @@
 # rabbitmq
 
-rabbitmq 监控采集插件，fork 自：telegraf/rabbitmq 。不过，这个插件用处不大了，因为从 rabbitmq 3.8 版本开始，就内置了 prometheus 的支持，即，如果 rabbitmq 启用了 prometheus，可以直接暴露 metrics 接口，Categraf 从这个 metrics 接口拉取数据即可
+rabbitmq 监控采集插件，fork 自：[telegraf/rabbitmq](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/rabbitmq) 。不过，这个插件用处不大了，因为从 rabbitmq 3.8 版本开始，就内置了 prometheus 的支持，即，如果 rabbitmq 启用了 prometheus，可以直接暴露 metrics 接口，Categraf 从这个 metrics 接口拉取数据即可
 
 rabbitmq 启用 prometheus 插件：
 

--- a/inputs/sqlserver/README.md
+++ b/inputs/sqlserver/README.md
@@ -1,6 +1,6 @@
-# kubernetes
+# SQL Server
 
-forked from telegraf/sqlserver. 这个插件的作用是获取sqlserver的监控指标，这里去掉了Azure相关部分监控，只保留了本地部署sqlserver情况。
+forked from [telegraf/sqlserver](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/sqlserver). 这个插件的作用是获取sqlserver的监控指标，这里去掉了Azure相关部分监控，只保留了本地部署sqlserver情况。
 
 # 按照下面方法创建监控账号，用于读取监控数据
 USE master;


### PR DESCRIPTION
修复一些不够严谨的情况：
- 一些地方是没有链接。
- 一些地方格式有误。
- 一些配置文件有误。