### PR TITLE
fix: ibex-windows cmd not support i18n charset

### DIFF
--- a/ibex/cmd_nix.go
+++ b/ibex/cmd_nix.go
@@ -15,3 +15,13 @@ func CmdStart(cmd *exec.Cmd) error {
 func CmdKill(cmd *exec.Cmd) error {
 	return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 }
+
+func ansiToUtf8(mbcs []byte) (string, error) {
+	// fake
+	return string(mbcs), nil
+}
+
+func utf8ToAnsi(utf8 string) (string, error) {
+	// fake
+	return utf8, nil
+}

--- a/ibex/cmd_windows.go
+++ b/ibex/cmd_windows.go
@@ -4,7 +4,18 @@ package ibex
 
 import (
 	"os/exec"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
+
+var kernel32 = windows.NewLazySystemDLL("kernel32")
+var multiByteToWideChar = kernel32.NewProc("MultiByteToWideChar")
+var wideCharToMultiByte = kernel32.NewProc("WideCharToMultiByte")
+
+const CP_ACP = 0        // default to ANSI code page
+const CP_OEMCP = 1      // default to OEM  code page
+const CP_THREAD_ACP = 3 // current thread's ANSI code page
 
 func CmdStart(cmd *exec.Cmd) error {
 	return cmd.Start()
@@ -12,4 +23,43 @@ func CmdStart(cmd *exec.Cmd) error {
 
 func CmdKill(cmd *exec.Cmd) error {
 	return cmd.Process.Kill()
+}
+
+func ansiToUtf8(mbcs []byte) (string, error) {
+	if mbcs == nil || len(mbcs) <= 0 {
+		return "", nil
+	}
+	// https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-multibytetowidechar#syntax
+	// ansi -> utf16
+	size, _, _ := multiByteToWideChar.Call(CP_ACP, 0, uintptr(unsafe.Pointer(&mbcs[0])), uintptr(len(mbcs)), uintptr(0), 0)
+	if size <= 0 {
+		return "", windows.GetLastError()
+	}
+	utf16 := make([]uint16, size)
+	rc, _, _ := multiByteToWideChar.Call(CP_ACP, 0, uintptr(unsafe.Pointer(&mbcs[0])), uintptr(len(mbcs)), uintptr(unsafe.Pointer(&utf16[0])), size)
+	if rc == 0 {
+		return "", windows.GetLastError()
+	}
+	return windows.UTF16ToString(utf16), nil
+}
+
+func utf8ToAnsi(utf8 string) ([]byte, error) {
+	utf16, err := windows.UTF16FromString(utf8)
+	if err != nil {
+		return nil, err
+	}
+	// https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte
+	size, _, _ := wideCharToMultiByte.Call(CP_ACP, 0, uintptr(unsafe.Pointer(&utf16[0])), uintptr(len(utf16)), uintptr(0), 0, uintptr(0), uintptr(0))
+	if size <= 0 {
+		return nil, windows.GetLastError()
+	}
+	mbcs := make([]byte, size)
+	rc, _, _ := wideCharToMultiByte.Call(CP_ACP, 0, uintptr(unsafe.Pointer(&utf16[0])), uintptr(len(utf16)), uintptr(unsafe.Pointer(&mbcs[0])), size, uintptr(0), uintptr(0))
+	if rc == 0 {
+		return nil, windows.GetLastError()
+	}
+	if mbcs[size-1] == 0 {
+		mbcs = mbcs[:size-1]
+	}
+	return mbcs, nil
 }

--- a/ibex/cmd_windows.go
+++ b/ibex/cmd_windows.go
@@ -43,23 +43,23 @@ func ansiToUtf8(mbcs []byte) (string, error) {
 	return windows.UTF16ToString(utf16), nil
 }
 
-func utf8ToAnsi(utf8 string) ([]byte, error) {
+func utf8ToAnsi(utf8 string) (string, error) {
 	utf16, err := windows.UTF16FromString(utf8)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	// https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte
 	size, _, _ := wideCharToMultiByte.Call(CP_ACP, 0, uintptr(unsafe.Pointer(&utf16[0])), uintptr(len(utf16)), uintptr(0), 0, uintptr(0), uintptr(0))
 	if size <= 0 {
-		return nil, windows.GetLastError()
+		return "", windows.GetLastError()
 	}
 	mbcs := make([]byte, size)
 	rc, _, _ := wideCharToMultiByte.Call(CP_ACP, 0, uintptr(unsafe.Pointer(&utf16[0])), uintptr(len(utf16)), uintptr(unsafe.Pointer(&mbcs[0])), size, uintptr(0), uintptr(0))
 	if rc == 0 {
-		return nil, windows.GetLastError()
+		return "", windows.GetLastError()
 	}
 	if mbcs[size-1] == 0 {
 		mbcs = mbcs[:size-1]
 	}
-	return mbcs, nil
+	return string(mbcs), nil
 }

--- a/ibex/task.go
+++ b/ibex/task.go
@@ -79,12 +79,12 @@ func (t *Task) GetStdout() string {
 	// window exec out charset is ANSI, convert to utf-8. (pwsh and cmd same)
 	case "windows":
 		b := buf.Bytes()
-		encoded, err := ansiToUtf8(b)
+		decoded, err := ansiToUtf8(b)
 		if err != nil {
 			log.Printf("E! convert out to windows-ansi fail: %v", err)
 			out = string(b)
 		}
-		out = encoded
+		out = decoded
 	default:
 		out = buf.String()
 	}
@@ -103,12 +103,12 @@ func (t *Task) GetStderr() string {
 	// window exec out charset is ANSI, convert to utf-8. (pwsh and cmd same)
 	case "windows":
 		b := buf.Bytes()
-		encoded, err := ansiToUtf8(b)
+		decoded, err := ansiToUtf8(b)
 		if err != nil {
 			log.Printf("E! convert out to windows-ansi fail: %v", err)
 			out = string(b)
 		}
-		out = encoded
+		out = decoded
 	default:
 		out = buf.String()
 	}
@@ -213,14 +213,14 @@ func (t *Task) prepare() error {
 				log.Printf("E! convert stdin[%s] to windows-ansi fail: %v", stdin, err)
 				return err
 			}
-			stdin = string(encodedStdin)
+			stdin = encodedStdin
 
 			encodedArgs, err := utf8ToAnsi(args)
 			if err != nil {
 				log.Printf("E! convert args[%s] to windows-ansi fail: %v", args, err)
 				return err
 			}
-			args = string(encodedArgs)
+			args = encodedArgs
 
 			script = strings.ReplaceAll(script, "\r", "")
 			script = strings.ReplaceAll(script, "\n", "\r\n")

--- a/ibex/task.go
+++ b/ibex/task.go
@@ -70,14 +70,49 @@ func (t *Task) SetAlive(pa bool) {
 
 func (t *Task) GetStdout() string {
 	t.Lock()
-	out := t.Stdout.String()
+
+	buf := t.Stdout
+
+	var out string
+
+	switch runtime.GOOS {
+	// window exec out charset is ANSI, convert to utf-8. (pwsh and cmd same)
+	case "windows":
+		b := buf.Bytes()
+		encoded, err := ansiToUtf8(b)
+		if err != nil {
+			log.Printf("E! convert out to windows-ansi fail: %v", err)
+			out = string(b)
+		}
+		out = encoded
+	default:
+		out = buf.String()
+	}
+
 	t.Unlock()
 	return out
 }
 
 func (t *Task) GetStderr() string {
 	t.Lock()
-	out := t.Stderr.String()
+
+	buf := t.Stderr
+
+	var out string
+	switch runtime.GOOS {
+	// window exec out charset is ANSI, convert to utf-8. (pwsh and cmd same)
+	case "windows":
+		b := buf.Bytes()
+		encoded, err := ansiToUtf8(b)
+		if err != nil {
+			log.Printf("E! convert out to windows-ansi fail: %v", err)
+			out = string(b)
+		}
+		out = encoded
+	default:
+		out = buf.String()
+	}
+
 	t.Unlock()
 	return out
 }
@@ -171,8 +206,32 @@ func (t *Task) prepare() error {
 
 		switch runtime.GOOS {
 		case "windows":
+			// window command(cmd) only support ANSI and CRLF
+			// if change to powershell , not convert script and stdin to ANSI and CRLF
+			encodedStdin, err := utf8ToAnsi(stdin)
+			if err != nil {
+				log.Printf("E! convert stdin[%s] to windows-ansi fail: %v", stdin, err)
+				return err
+			}
+			stdin = string(encodedStdin)
+
+			encodedArgs, err := utf8ToAnsi(args)
+			if err != nil {
+				log.Printf("E! convert args[%s] to windows-ansi fail: %v", args, err)
+				return err
+			}
+			args = string(encodedArgs)
+
+			script = strings.ReplaceAll(script, "\r", "")
+			script = strings.ReplaceAll(script, "\n", "\r\n")
+			encodedScript, err := utf8ToAnsi(script)
+			if err != nil {
+				log.Printf("E! convert script to windows-ansi fail: %v", err)
+				return err
+			}
+
 			scriptFile := filepath.Join(IdDir, "script.bat")
-			_, err = file.WriteString(scriptFile, fmt.Sprintf("@echo off\r\n%s", script))
+			_, err = file.WriteString(scriptFile, fmt.Sprintf("@echo off\r\n%s", encodedScript))
 			if err != nil {
 				log.Printf("E! write script to %s fail: %v", scriptFile, err)
 				return err


### PR DESCRIPTION
Windows cmd 需要使用  ANSI 编码 + CRLF 换行的脚本。


- 使用 Windows API 转换 ANSI，而不是 golang.org/x/text/encoding 转换，确保最大兼容性，结果一定与机器匹配。


fix https://github.com/flashcatcloud/categraf/issues/1018