### PR TITLE
fix: get the error sn when there is some warning like redhat os

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -341,7 +341,16 @@ func GetBiosSn() (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("failed to get bios sn: %v", err)
 		}
-		sn = strings.TrimSpace(string(out))
+		lines := strings.Split(string(out), "\n")
+		for _, line := range lines {
+			if strings.HasPrefix(line, "#") {
+				continue
+			}
+			if len(line) > 0 {
+				sn = strings.TrimSpace(line)
+				break
+			}
+		}
 	default:
 		return "", fmt.Errorf("not support os to get sn")
 	}


### PR DESCRIPTION
get the error sn when there is some warning like redhat os
like this
![image](https://github.com/user-attachments/assets/37654aae-8103-473b-a281-cdeda5fdfb0e)
