### PR TITLE
chore: Add rate limiting log

### DIFF
--- a/logs/sender/batch_strategy.go
+++ b/logs/sender/batch_strategy.go
@@ -108,6 +108,10 @@ func (s *batchStrategy) processMessage(m *message.Message, outputChan chan *mess
 	}
 	added := s.buffer.AddMessage(m)
 	if !added || s.buffer.IsFull() {
+		if s.buffer.IsFull() {
+			log.Printf("I! buffer full len: %d, size: %d",
+				len(s.buffer.messageBuffer), s.buffer.contentSize)
+		}
 		s.flushBuffer(outputChan, send)
 	}
 	if !added {


### PR DESCRIPTION
增加触发限流的标识
如果缓存允许最大并发批次是1k，如下
![image](https://github.com/user-attachments/assets/bb22ff41-06fa-421c-b11d-0115d0b52688)

但是实际处理过程中，如果有发现超过1k的并发，那么应该有标识，标识输出的内容是：“buffer full”
![image](https://github.com/user-attachments/assets/525eee52-9ccc-473a-9c6d-af9c1a0bf803)

同时可以配合mtail发现关键字，进一步针对指标配置阈值、告警，一气呵成
![image](https://github.com/user-attachments/assets/6def25e6-d9ca-4f3c-9643-99de8aa99516)
![image](https://github.com/user-attachments/assets/93862386-ffd9-46a1-bb05-4158f2a56c1b)


需要注意的一点是：
如果采集的内容达到一次发送的上限，也会直接发送走，不会触发该标识。所以需要合理定义batch_max_size、batch_max_content_size大小
