### PR TITLE
fix: df use the POSIX output format

### DIFF
--- a/heartbeat/filesystem/filesystem_linux.go
+++ b/heartbeat/filesystem/filesystem_linux.go
@@ -5,7 +5,7 @@
 
 package filesystem
 
-var dfOptions = []string{"-l"}
+var dfOptions = []string{"-lP"}
 var expectedLength = 6
 
 func updatefileSystemInfo(values []string) map[string]string {


### PR DESCRIPTION
fix bug if the disk name is too long to display
for example:
![image](https://github.com/user-attachments/assets/d6525040-e2cc-4e10-ac5a-f7cad7c94c4c)
