### PR TITLE
fix: 修复redis_sentinel标签异常

### DIFF
--- a/inputs/redis_sentinel/redis_sentinel.go
+++ b/inputs/redis_sentinel/redis_sentinel.go
@@ -183,7 +183,6 @@ func convertSentinelInfoOutput(
 	scanner := bufio.NewScanner(rdr)
 	rawFields := make(map[string]string)
 
-	// tags := globalTags
 	tags := make(map[string]string, len(globalTags))
 	for k, v := range globalTags {
 		tags[k] = v
@@ -272,7 +271,6 @@ func convertSentinelSentinelsOutput(
 	masterName string,
 	sentinelMaster map[string]string,
 ) (map[string]string, map[string]interface{}, error) {
-	//tags := globalTags
 	tags := make(map[string]string, len(globalTags))
 	for k, v := range globalTags {
 		tags[k] = v
@@ -328,7 +326,6 @@ func convertSentinelReplicaOutput(
 	masterName string,
 	replica map[string]string,
 ) (map[string]string, map[string]interface{}, error) {
-	//tags := globalTags
 	tags := make(map[string]string, len(globalTags))
 	for k, v := range globalTags {
 		tags[k] = v
@@ -395,7 +392,6 @@ func convertSentinelMastersOutput(
 	master map[string]string,
 	quorumErr error,
 ) (map[string]string, map[string]interface{}, error) {
-	//tags := globalTags
 	tags := make(map[string]string, len(globalTags))
 	for k, v := range globalTags {
 		tags[k] = v

--- a/inputs/redis_sentinel/redis_sentinel.go
+++ b/inputs/redis_sentinel/redis_sentinel.go
@@ -183,7 +183,11 @@ func convertSentinelInfoOutput(
 	scanner := bufio.NewScanner(rdr)
 	rawFields := make(map[string]string)
 
-	tags := globalTags
+	// tags := globalTags
+	tags := make(map[string]string, len(globalTags))
+	for k, v := range globalTags {
+		tags[k] = v
+	}
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -268,7 +272,11 @@ func convertSentinelSentinelsOutput(
 	masterName string,
 	sentinelMaster map[string]string,
 ) (map[string]string, map[string]interface{}, error) {
-	tags := globalTags
+	//tags := globalTags
+	tags := make(map[string]string, len(globalTags))
+	for k, v := range globalTags {
+		tags[k] = v
+	}
 
 	tags["sentinel_ip"] = sentinelMaster["ip"]
 	tags["sentinel_port"] = sentinelMaster["port"]
@@ -320,7 +328,11 @@ func convertSentinelReplicaOutput(
 	masterName string,
 	replica map[string]string,
 ) (map[string]string, map[string]interface{}, error) {
-	tags := globalTags
+	//tags := globalTags
+	tags := make(map[string]string, len(globalTags))
+	for k, v := range globalTags {
+		tags[k] = v
+	}
 
 	tags["replica_ip"] = replica["ip"]
 	tags["replica_port"] = replica["port"]
@@ -383,7 +395,11 @@ func convertSentinelMastersOutput(
 	master map[string]string,
 	quorumErr error,
 ) (map[string]string, map[string]interface{}, error) {
-	tags := globalTags
+	//tags := globalTags
+	tags := make(map[string]string, len(globalTags))
+	for k, v := range globalTags {
+		tags[k] = v
+	}
 
 	tags["master"] = master["name"]
 


### PR DESCRIPTION
这里的tag修改的都是client.tags这个map，每一次修改都会更新同名标签，并且导致tag累积，后面的指标被添加了很多无关的标签