### PR TITLE
chore: add procstat input ExcludeSearchString option

### DIFF
--- a/inputs/procstat/procstat.go
+++ b/inputs/procstat/procstat.go
@@ -50,6 +50,8 @@ type Instance struct {
 	searchString string
 	solarisMode  bool
 	procs        map[PID]Process
+
+	ExcludeSearchString bool `toml:"exclude_search_string"`
 }
 
 func (ins *Instance) Init() error {
@@ -156,9 +158,13 @@ func (ins *Instance) Gather(slist *types.SampleList) {
 	var (
 		pids []PID
 		err  error
-		tags = map[string]string{"search_string": ins.searchString}
+		tags = map[string]string{}
 		opts = []Filter{}
 	)
+
+	if !ins.ExcludeSearchString {
+		tags["search_string"] = ins.searchString
+	}
 
 	if ins.SearchUser != "" {
 		opts = append(opts, UserFilter(ins.SearchUser))


### PR DESCRIPTION
In some cases, search_string is too complex and you don't want to include it in the metrics. Choose not to include the search string and use custom labels to identify the metrics.