### PR TITLE
fix(oracle): configuration file errors

### DIFF
--- a/conf/input.oracle/metric.toml
+++ b/conf/input.oracle/metric.toml
@@ -120,3 +120,4 @@ metric_fields = [ "value" ]
 timeout = "3s"
 request = '''
 SELECT TO_NUMBER(EXTRACT(SECOND FROM TO_DSINTERVAL (value))) as value FROM v$dataguard_stats WHERE name = 'apply lag'
+'''

--- a/conf/input.oracle/oracle.toml
+++ b/conf/input.oracle/oracle.toml
@@ -1,7 +1,7 @@
 # # collect interval
 # interval = 15
 
-#[[instances]]
+# [[instances]]
 # address = "10.1.2.3:1521/orcl"
 # username = "monitor"
 # password = "123456"


### PR DESCRIPTION
修复配置文件错误，原来的配置文件会导致 oracle 无法加载：

1. W! no instances for input:oracle
2. E! failed to load configuration of plugin: local.oracle error: toml: line 140 (last key "metrics.request"): unexpected EOF; expected "'''"

