### PR TITLE
chore(es): Remove the legacy configuration item num_most_recent_indices

### DIFF
--- a/conf/input.elasticsearch/elasticsearch.toml
+++ b/conf/input.elasticsearch/elasticsearch.toml
@@ -100,9 +100,3 @@ cluster_info_interval = "5m"
 # tls_key = "/etc/categraf/key.pem"
 ## Use TLS but skip chain & host verification
 # insecure_skip_verify = true
-
-## Sets the number of most recent indices to return for indices that are configured with a date-stamped suffix.
-## Each 'indices_include' entry ending with a wildcard (*) or glob matching pattern will group together all indices that match it, and 
-## sort them by the date or number after the wildcard. Metrics then are gathered for only the 'num_most_recent_indices' amount of most 
-## recent indices.
-num_most_recent_indices = 1


### PR DESCRIPTION
```num_most_recent_indices```是telegraf的es插件配置，当前插件es exporter ， 没有这个配置项，先删除。 