### PR TITLE
补充elasticsearch插件num_most_recent_indices参数逻辑&完善indices_include生效范围

### DIFF
--- a/inputs/elasticsearch/collector/ilm_indices_test.go
+++ b/inputs/elasticsearch/collector/ilm_indices_test.go
@@ -14,6 +14,7 @@
 package collector
 
 import (
+	"flashcat.cloud/categraf/pkg/filter"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -97,7 +98,10 @@ elasticsearch_ilm_index_status{action="complete",index="facebook",phase="new",st
 				t.Fatal(err)
 			}
 
-			c := NewIlmIndicies(http.DefaultClient, u)
+			indicesIncluded := make([]string, 0)
+			var numMostRecentIndices int = 0
+			indexMatchers := make(map[string]filter.Filter)
+			c := NewIlmIndicies(http.DefaultClient, u, indicesIncluded, numMostRecentIndices, indexMatchers)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/inputs/elasticsearch/collector/indices_mappings_test.go
+++ b/inputs/elasticsearch/collector/indices_mappings_test.go
@@ -14,6 +14,7 @@
 package collector
 
 import (
+	"flashcat.cloud/categraf/pkg/filter"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -112,7 +113,10 @@ elasticsearch_indices_mappings_stats_fields{index="test-data-2023.01.20"} 40
 				t.Fatal(err)
 			}
 
-			c := NewIndicesMappings(http.DefaultClient, u)
+			indicesIncluded := make([]string, 0)
+			var numMostRecentIndices int = 0
+			indexMatchers := make(map[string]filter.Filter)
+			c := NewIndicesMappings(http.DefaultClient, u, indicesIncluded, numMostRecentIndices, indexMatchers)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/inputs/elasticsearch/collector/indices_settings_test.go
+++ b/inputs/elasticsearch/collector/indices_settings_test.go
@@ -14,6 +14,7 @@
 package collector
 
 import (
+	"flashcat.cloud/categraf/pkg/filter"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -68,7 +69,10 @@ func TestIndicesSettings(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to parse URL: %s", err)
 			}
-			c := NewIndicesSettings(http.DefaultClient, u)
+			indicesIncluded := make([]string, 0)
+			var numMostRecentIndices int = 0
+			indexMatchers := make(map[string]filter.Filter)
+			c := NewIndicesSettings(http.DefaultClient, u, indicesIncluded, numMostRecentIndices, indexMatchers)
 			nsr, err := c.fetchAndDecodeIndicesSettings()
 			if err != nil {
 				t.Fatalf("Failed to fetch or decode indices settings: %s", err)

--- a/inputs/elasticsearch/collector/indices_test.go
+++ b/inputs/elasticsearch/collector/indices_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"flashcat.cloud/categraf/pkg/filter"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -34,8 +35,11 @@ func TestIndices(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to parse URL: %s", err)
 		}
-		indices := make([]string, 0)
-		i := NewIndices(http.DefaultClient, u, false, false, indices)
+		//indices := make([]string, 0)
+		indicesIncluded := make([]string, 0)
+		var numMostRecentIndices int = 0
+		indexMatchers := make(map[string]filter.Filter)
+		i := NewIndices(http.DefaultClient, u, false, true, indicesIncluded, numMostRecentIndices, indexMatchers)
 		stats, err := i.fetchAndDecodeIndexStats()
 		if err != nil {
 			t.Fatalf("Failed to fetch or decode indices stats: %s", err)
@@ -56,7 +60,7 @@ func TestIndices(t *testing.T) {
 		if stats.Indices["foo_1"].Total.Indexing.IndexTotal == 0 {
 			t.Errorf("Wrong indexing total recorded")
 		}
-		if stats.Aliases != nil {
+		if len(stats.Aliases) != 0 {
 			t.Errorf("Aliases are populated when they should not be")
 		}
 	}
@@ -109,8 +113,11 @@ func TestAliases(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to parse URL: %s", err)
 		}
-		indices := make([]string, 0)
-		i := NewIndices(http.DefaultClient, u, false, true, indices)
+		//indices := make([]string, 0)
+		indicesIncluded := make([]string, 0)
+		var numMostRecentIndices int = 0
+		indexMatchers := make(map[string]filter.Filter)
+		i := NewIndices(http.DefaultClient, u, false, true, indicesIncluded, numMostRecentIndices, indexMatchers)
 		stats, err := i.fetchAndDecodeIndexStats()
 		if err != nil {
 			t.Fatalf("Failed to fetch or decode indices stats: %s", err)

--- a/inputs/elasticsearch/elasticsearch.go
+++ b/inputs/elasticsearch/elasticsearch.go
@@ -56,7 +56,7 @@ type (
 		ExportIndices         bool            `toml:"export_indices"`
 		ExportIndicesSettings bool            `toml:"export_indices_settings"`
 		ExportIndicesMappings bool            `toml:"export_indices_mappings"`
-		ExportIndexAliases    bool            `toml:"export_index_aliases"`
+		ExportIndexAliases    bool            `toml:"export_indices_aliases"`
 		ExportILM             bool            `toml:"export_ilm"`
 		ExportShards          bool            `toml:"export_shards"`
 		ExportSLM             bool            `toml:"export_slm"`
@@ -67,6 +67,7 @@ type (
 		ClusterInfoInterval   config.Duration `toml:"cluster_info_interval"`
 		AwsRegion             string          `toml:"aws_region"`
 		AwsRoleArn            string          `toml:"aws_role_arn"`
+		NumMostRecentIndices  int             `toml:"num_most_recent_indices"`
 
 		EsURL *url.URL
 		*http.Client
@@ -244,7 +245,7 @@ func (ins *Instance) Gather(slist *types.SampleList) {
 				if err := inputs.Collect(sC, slist); err != nil {
 					log.Println("E! failed to collect shards metrics:", err)
 				}
-				iC := collector.NewIndices(ins.Client, EsUrl, ins.ExportShards, ins.ExportIndexAliases, ins.IndicesInclude)
+				iC := collector.NewIndices(ins.Client, EsUrl, ins.ExportShards, ins.ExportIndexAliases, ins.IndicesInclude, ins.NumMostRecentIndices, ins.indexMatchers)
 				if err := inputs.Collect(iC, slist); err != nil {
 					log.Println("E! failed to collect indices metrics:", err)
 				}
@@ -269,13 +270,13 @@ func (ins *Instance) Gather(slist *types.SampleList) {
 			}
 
 			if ins.ExportIndicesSettings {
-				if err := inputs.Collect(collector.NewIndicesSettings(ins.Client, EsUrl), slist); err != nil {
+				if err := inputs.Collect(collector.NewIndicesSettings(ins.Client, EsUrl, ins.IndicesInclude, ins.NumMostRecentIndices, ins.indexMatchers), slist); err != nil {
 					log.Println("E! failed to collect indices settings metrics:", err)
 				}
 			}
 
 			if ins.ExportIndicesMappings {
-				if err := inputs.Collect(collector.NewIndicesMappings(ins.Client, EsUrl), slist); err != nil {
+				if err := inputs.Collect(collector.NewIndicesMappings(ins.Client, EsUrl, ins.IndicesInclude, ins.NumMostRecentIndices, ins.indexMatchers), slist); err != nil {
 					log.Println("E! failed to collect indices mappings metrics:", err)
 				}
 			}
@@ -290,7 +291,7 @@ func (ins *Instance) Gather(slist *types.SampleList) {
 				if err := inputs.Collect(collector.NewIlmStatus(ins.Client, EsUrl), slist); err != nil {
 					log.Println("E! failed to collect ilm status metrics:", err)
 				}
-				if err := inputs.Collect(collector.NewIlmIndicies(ins.Client, EsUrl), slist); err != nil {
+				if err := inputs.Collect(collector.NewIlmIndicies(ins.Client, EsUrl, ins.IndicesInclude, ins.NumMostRecentIndices, ins.indexMatchers), slist); err != nil {
 					log.Println("E! failed to collect ilm indices metrics:", err)
 				}
 			}


### PR DESCRIPTION
1、elasticsearch插件增加num_most_recent_indices参数处理逻辑
2、补充elasticsearch插件ilm_indices、indices_settings、indices_mappings、indices_aliases 参数indices_include生效逻辑以及参数num_most_recent_indices处理逻辑