### PR TITLE
Update bonding_linux.go

### DIFF
--- a/inputs/node_exporter/collector/bonding_linux.go
+++ b/inputs/node_exporter/collector/bonding_linux.go
@@ -86,6 +86,10 @@ func readBondingStats(root string) (status map[string][2]int, err error) {
 			if errors.Is(err, os.ErrNotExist) {
 				// some older? kernels use slave_ prefix
 				state, err = os.ReadFile(filepath.Join(root, master, fmt.Sprintf("slave_%s", slave), "bonding_slave", "mii_status"))
+				if errors.Is(err, os.ErrNotExist) {
+					//  other older kernels like redhat 6.5
+					state, err = os.ReadFile(filepath.Join(root, master, fmt.Sprintf("slave_%s", slave), "operstate"))
+				}
 			}
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
fix bonding collect for redhat 6.5
兼容性修复
![image](https://github.com/user-attachments/assets/81d81100-4f9a-41f9-9377-f5f360699c13)
