### PR TITLE
Fix: The issue of goroutine leakage when freeipmi is not installed

### DIFF
--- a/inputs/ipmi/exporter/freeipmi/freeipmi.go
+++ b/inputs/ipmi/exporter/freeipmi/freeipmi.go
@@ -137,6 +137,10 @@ func freeipmiConfigPipe(config string) (string, error) {
 }
 
 func Execute(cmd string, args []string, config string, target string, debugMod bool) Result {
+	if _, err := exec.LookPath(cmd); err != nil {
+		return Result{nil, fmt.Errorf("executable %s not found in $PATH", cmd)}
+	}
+
 	pipe, err := freeipmiConfigPipe(config)
 	if err != nil {
 		return Result{nil, err}


### PR DESCRIPTION
**- 问题：**
如果系统没有安装 freeipmi 相关命令，categraf 日志会持续报错 “executable file not found in $PATH”，同时进程线程数会不断增长，未被释放。

<img width="449" alt="28642268227d74994d091d0799deac4" src="https://github.com/user-attachments/assets/60bb397e-d856-4be2-b5d9-09c50f8ee8f3" />
<img width="653" alt="6c081941cc1b9ebf0ecbde4895e5299" src="https://github.com/user-attachments/assets/0fd962ae-0463-44c0-9c3d-007be0bc5b16" />


**- 原因：**
每次调用 Execute 时，都会调用 freeipmiConfigPipe 创建一个 goroutine，用于向 named pipe（FIFO 文件）写入 config 数据。
如果 freeipmi 相关命令不存在，exec.Command(cmd, args...).CombinedOutput() 会立即失败，不会读取 named pipe。
此时 goroutine 在尝试打开 named pipe (os.OpenFile) 时会阻塞，因为 FIFO 的写端没有被读端打开，OpenFile 无法返回。
由于外部命令没有启动（或启动失败），FIFO 的读端永远不会打开，写端的 goroutine 永远不会退出，导致线程/协程泄漏。
后续的逻辑：
```
defer func() {
		if err := os.Remove(pipe); err != nil {
			log.Println("msg", "Error deleting named pipe", "error", err)
		}
	}()
```
即使 pipe 文件被删除，openFile 阻塞的 goroutine 也不会收到通知退出，还是会卡着。


**- 解决：**
在创建 pipe 和写 goroutine 前，先检查命令是否存在，避免无意义的 goroutine 启动。
```
if _, err := exec.LookPath(cmd); err != nil {
		return Result{nil, fmt.Errorf("executable %s not found in $PATH", cmd)}
	}
```