### PR TITLE
新增mongodb监控用户权限说明

### DIFF
--- a/inputs/mongodb/README.md
+++ b/inputs/mongodb/README.md
@@ -19,6 +19,8 @@ mongodb 监控采集插件，由mongodb-exporter（https://github.com/percona/mo
       }
 
     ```
+
+
   一个简单配置
     ```
     mongo -h xxx -u xxx -p xxx --authenticationDatabase admin
@@ -26,6 +28,25 @@ mongodb 监控采集插件，由mongodb-exporter（https://github.com/percona/mo
     > db.createUser({user:"categraf",pwd:"categraf",roles: [{role:"read",db:"local"},{"role":"clusterMonitor","db":"admin"}]})
     ```
     更详细的权限配置请参考[官方文档](https://www.mongodb.com/docs/manual/reference/built-in-roles/#mongodb-authrole-clusterMonitor)
+
+    
+### 注意事项
+  > 如果MongoDB 开启了operationProfiling仅用以上权限会出现system.profile无权限错误，默认的mongo角色中对system.profile集合只有find权限，要解决这个问题需要创建一个新的角色。
+  ```
+  db.createRole({
+    role: "StatsReader",
+    privileges: [
+      {
+        resource: { db: "", collection: "system.profile" },
+        actions: [ "collStats", "indexStats" ]
+      }
+    ],
+    roles: []
+  })
+
+  # 给categraf用户授权
+  db.grantRolesToUser("categraf",[{ role: "StatsReader", db: "admin" }])
+  ```
 
 ## 监控大盘和告警规则
 


### PR DESCRIPTION
新增mongodb监控用户权限说明，如果按照官方默认配置会出现 not authorized on mljy to execute command { aggregate: \"system.profile\", pipeline: [ { $indexStats: {} } ], cursor: {}, lsid: { id: UUID(\"5e18cebb-e5d0-4580-a2c7-9646ec1470d1\") }错误