### PR TITLE
永远保留pod、namaspance这两个标签以便能够从 cadvisor metric 中获取 pod/namespace 来查 cache。

### DIFF
--- a/inputs/cadvisor/instances.go
+++ b/inputs/cadvisor/instances.go
@@ -276,6 +276,10 @@ func (ins *Instance) gather(buf []byte, header http.Header, defaultLabels map[st
 }
 
 func (ins *Instance) ignoreLabel(label string) bool {
+	// 永远保留这两个标签以便能够从 cadvisor metric 中获取 pod/namespace 来查 cache
+	if label == "pod" || label == "namespace" {
+		return false
+	}
 	if ins.chooseLabelKeysFilter != nil {
 		if ins.chooseLabelKeysFilter.Match(label) {
 			return false


### PR DESCRIPTION
如果不加代码，choose_label_keys不写["*"]或者["pod","namespace"]，makeLabels方法中if ins.ignoreLabel(label.GetName()) {的判断为true，导致取不到标签的值。 所以永远保留这两个标签以便能够从 cadvisor metric 中获取 pod/namespace 来查 cache。