### PR TITLE
feat: add gpu index for nvidia-smi input

### DIFF
--- a/inputs/nvidia_smi/fields.go
+++ b/inputs/nvidia_smi/fields.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	uuidQField               qField = "uuid"
+	indexQField              qField = "index"
 	nameQField               qField = "name"
 	driverModelCurrentQField qField = "driver_model.current"
 	driverModelPendingQField qField = "driver_model.pending"

--- a/inputs/nvidia_smi/nvidia_smi.go
+++ b/inputs/nvidia_smi/nvidia_smi.go
@@ -80,6 +80,7 @@ func (s *GPUStats) Gather(slist *types.SampleList) {
 
 	for _, currentRow := range currentTable.rows {
 		uuid := strings.TrimPrefix(strings.ToLower(currentRow.qFieldToCells[uuidQField].rawValue), "gpu-")
+		index := currentRow.qFieldToCells[indexQField].rawValue
 		name := currentRow.qFieldToCells[nameQField].rawValue
 		driverModelCurrent := currentRow.qFieldToCells[driverModelCurrentQField].rawValue
 		driverModelPending := currentRow.qFieldToCells[driverModelPendingQField].rawValue
@@ -88,6 +89,7 @@ func (s *GPUStats) Gather(slist *types.SampleList) {
 
 		slist.PushFront(types.NewSample(inputName, "gpu_info", 1, map[string]string{
 			"uuid":                 uuid,
+			"index":                index,
 			"name":                 name,
 			"driver_model_current": driverModelCurrent,
 			"driver_model_pending": driverModelPending,
@@ -106,7 +108,7 @@ func (s *GPUStats) Gather(slist *types.SampleList) {
 				continue
 			}
 
-			slist.PushFront(types.NewSample(inputName, metricInfo.metricName, num, map[string]string{"uuid": uuid}))
+			slist.PushFront(types.NewSample(inputName, metricInfo.metricName, num, map[string]string{"uuid": uuid, "index": index}))
 		}
 	}
 }

--- a/inputs/nvidia_smi/types.go
+++ b/inputs/nvidia_smi/types.go
@@ -24,6 +24,7 @@ var (
 
 	requiredFields = []qField{
 		uuidQField,
+		indexQField,
 		nameQField,
 		driverModelCurrentQField,
 		driverModelPendingQField,


### PR DESCRIPTION
When scraping configuration with nvidia-smi, it was found that the GPU index was missing. This commit adds an index label to the metric labels.