### PR TITLE
feat(inputs): 新增海光 GPU hy_smi 采集插件

### DIFF
--- a/agent/metrics_agent.go
+++ b/agent/metrics_agent.go
@@ -42,6 +42,7 @@ import (
 	_ "flashcat.cloud/categraf/inputs/haproxy"
 	_ "flashcat.cloud/categraf/inputs/http_response"
 	_ "flashcat.cloud/categraf/inputs/huatuo"
+	_ "flashcat.cloud/categraf/inputs/hy_smi"
 	_ "flashcat.cloud/categraf/inputs/influxdb"
 	_ "flashcat.cloud/categraf/inputs/ipmi"
 	_ "flashcat.cloud/categraf/inputs/iptables"

--- a/conf/input.hy_smi/hy_smi.toml
+++ b/conf/input.hy_smi/hy_smi.toml
@@ -2,7 +2,8 @@
 # interval = 15
 
 # exec local command
-# hy_smi_command = "/opt/hyhal/bin/hy-smi --showid --showvbios --showdriverversion --showuse --showmemuse --showvoltage --showtemp --json"
+# e.g. hy_smi_command = "/opt/hyhal/bin/hy-smi --showid --showvbios --showdriverversion --showuse --showmemuse --showvoltage --showtemp --json"
+# hy_smi_command = ""
 
 # exec remote command
 # hy_smi_command = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null SSH_USER@SSH_HOST hy-smi --showid --showvbios --showdriverversion --showuse --showmemuse --showvoltage --showtemp --json"

--- a/conf/input.hy_smi/hy_smi.toml
+++ b/conf/input.hy_smi/hy_smi.toml
@@ -1,0 +1,11 @@
+# # collect interval
+# interval = 15
+
+# exec local command
+# hy_smi_command = "/opt/hyhal/bin/hy-smi --showid --showvbios --showdriverversion --showuse --showmemuse --showvoltage --showtemp --json"
+
+# exec remote command
+# hy_smi_command = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null SSH_USER@SSH_HOST hy-smi --showid --showvbios --showdriverversion --showuse --showmemuse --showvoltage --showtemp --json"
+
+# query_timeout is used to set the query timeout to avoid the delay of data collection.
+# query_timeout = "5s"

--- a/inputs/hy_smi/README.md
+++ b/inputs/hy_smi/README.md
@@ -1,0 +1,84 @@
+# hy_smi
+
+该采集插件用于采集海光（Hygon）GPU 的监控指标，原理是通过执行 `hy-smi` 命令并解析其 JSON 输出，转换为监控数据上报。
+
+## Configuration
+
+配置文件在 `conf/input.hy_smi/hy_smi.toml`
+
+```toml
+# collect interval
+interval = 15
+
+# exec local command
+hy_smi_command = "/opt/hyhal/bin/hy-smi --showid --showvbios --showdriverversion --showuse --showmemuse --showvoltage --showtemp --json"
+
+# 如果想远程方式采集远端机器的 GPU 状态信息，可以使用 ssh 命令登录远端机器执行
+# exec remote command
+# hy_smi_command = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null SSH_USER@SSH_HOST hy-smi --showid --showvbios --showdriverversion --showuse --showmemuse --showvoltage --showtemp --json"
+
+# query_timeout is used to set the query timeout to avoid the delay of data collection.
+query_timeout = "5s"
+```
+
+## Metrics
+
+- measurement: `hy_smi`
+    - tags
+        - `card` (GPU 卡名称，如 card0、card1)
+
+    - fields
+        - `gpu_info` (integer, 值为 1，携带 `device_id` 和 `vbios_version` 标签)
+        - `temperature_sensor_edge_celsius` (float, 边缘温度，单位：摄氏度)
+        - `temperature_sensor_junction_celsius` (float, 结点温度，单位：摄氏度)
+        - `temperature_sensor_mem_celsius` (float, 显存温度，单位：摄氏度)
+        - `temperature_sensor_core_celsius` (float, 核心温度，单位：摄氏度)
+        - `hcu_use_ratio` (float, HCU 使用率，0~1 之间)
+        - `hcu_memory_use_ratio` (float, HCU 显存使用率，0~1 之间)
+        - `voltage_millivolts` (float, 电压，单位：毫伏)
+        - `scraper_up` (integer, 采集是否成功，1 表示成功，0 表示失败)
+        - `scrape_use_seconds` (float, 采集耗时，单位：秒)
+
+## 前置条件
+
+- 需要安装海光 GPU 驱动及 `hy-smi` 工具，通常位于 `/opt/hyhal/bin/hy-smi`
+- `hy-smi` 命令需要支持 `--json` 参数输出 JSON 格式数据
+
+## 手动验证
+
+可以通过以下命令手动验证 `hy-smi` 是否正常工作：
+
+```sh
+/opt/hyhal/bin/hy-smi --showid --showvbios --showdriverversion --showuse --showmemuse --showvoltage --showtemp --json
+```
+
+预期输出类似：
+
+```json
+{
+  "card0": {
+    "Device ID": "0x6320",
+    "VBIOS version": "6.312.002400Q.984920",
+    "Driver version": "6.1.0",
+    "Temperature (Sensor edge) (C)": "35",
+    "Temperature (Sensor junction) (C)": "40",
+    "Temperature (Sensor mem) (C)": "30",
+    "Temperature (Sensor core) (C)": "33",
+    "HCU use (%)": "10",
+    "HCU memory use (%)": "5",
+    "Voltage (mV)": "800"
+  }
+}
+```
+
+## Example Output
+
+```text
+hy_smi,card=card0 temperature_sensor_edge_celsius=35,temperature_sensor_junction_celsius=40,temperature_sensor_mem_celsius=30,temperature_sensor_core_celsius=33,hcu_use_ratio=0.1,hcu_memory_use_ratio=0.05,voltage_millivolts=800 1630572550000000000
+hy_smi,card=card0,device_id=0x6320,vbios_version=6.312.002400Q.984920 gpu_info=1 1630572550000000000
+hy_smi scraper_up=1,scrape_use_seconds=0.12 1630572550000000000
+```
+
+## TODO
+
+GPU 卡已关注的监控指标，缺少监控大盘 JSON 和告警规则 JSON，欢迎大家 PR

--- a/inputs/hy_smi/hy_smi.go
+++ b/inputs/hy_smi/hy_smi.go
@@ -1,0 +1,164 @@
+package hy_smi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"flashcat.cloud/categraf/config"
+	"flashcat.cloud/categraf/inputs"
+	"flashcat.cloud/categraf/pkg/cmdx"
+	"flashcat.cloud/categraf/types"
+)
+
+const inputName = "hy_smi"
+
+type HySMI struct {
+	config.PluginConfig
+
+	HySmiCommand string          `toml:"hy_smi_command"`
+	QueryTimeOut config.Duration `toml:"query_timeout"`
+}
+
+func init() {
+	inputs.Add(inputName, func() inputs.Input {
+		return &HySMI{}
+	})
+}
+
+func (s *HySMI) Clone() inputs.Input {
+	return &HySMI{}
+}
+
+func (s *HySMI) Name() string {
+	return inputName
+}
+
+func (s *HySMI) Init() error {
+	if s.HySmiCommand == "" {
+		return types.ErrInstancesEmpty
+	}
+	if s.QueryTimeOut == 0 {
+		s.QueryTimeOut = config.Duration(5 * time.Second)
+	}
+	return nil
+}
+
+// cardStats represents the JSON structure returned by hy-smi --json
+// Example: {"card0": {"Device ID": "0x6320", "VBIOS version": "...", ...}}
+type cardStats map[string]map[string]string
+
+func (s *HySMI) Gather(slist *types.SampleList) {
+	if s.HySmiCommand == "" {
+		return
+	}
+	begun := time.Now()
+
+	defer func(begun time.Time) {
+		use := time.Since(begun).Seconds()
+		slist.PushFront(types.NewSample(inputName, "scrape_use_seconds", use))
+	}(begun)
+
+	stats, err := s.scrape()
+	if err != nil {
+		slist.PushFront(types.NewSample(inputName, "scraper_up", 0))
+		log.Println("E! failed to scrape hy-smi:", err)
+		return
+	}
+
+	slist.PushFront(types.NewSample(inputName, "scraper_up", 1))
+
+	for cardName, fields := range stats {
+		deviceID := fields["Device ID"]
+		vbiosVersion := fields["VBIOS version"]
+
+		// Push gpu_info as a gauge with value 1, carrying info labels
+		slist.PushFront(types.NewSample(inputName, "gpu_info", 1, map[string]string{
+			"card":          cardName,
+			"device_id":     deviceID,
+			"vbios_version": vbiosVersion,
+		}))
+
+		for fieldKey, rawValue := range fields {
+			// Skip string fields that are already used as info labels
+			if fieldKey == "Device ID" || fieldKey == "VBIOS version" {
+				continue
+			}
+
+			metricName, multiplier := fieldToMetric(fieldKey)
+			if metricName == "" {
+				if s.DebugMod {
+					log.Println("D! hy_smi: unknown field:", fieldKey, "value:", rawValue)
+				}
+				continue
+			}
+
+			val, err := strconv.ParseFloat(strings.TrimSpace(rawValue), 64)
+			if err != nil {
+				if s.DebugMod {
+					log.Println("D! hy_smi: failed to parse field:", fieldKey, "raw value:", rawValue, "error:", err)
+				}
+				continue
+			}
+
+			slist.PushFront(types.NewSample(inputName, metricName, val*multiplier, map[string]string{
+				"card": cardName,
+			}))
+		}
+	}
+}
+
+func (s *HySMI) scrape() (cardStats, error) {
+	cmdAndArgs := strings.Fields(s.HySmiCommand)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	cmd := exec.Command(cmdAndArgs[0], cmdAndArgs[1:]...) //nolint:gosec
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err, timeout := cmdx.RunTimeout(cmd, time.Duration(s.QueryTimeOut))
+	if timeout {
+		return nil, fmt.Errorf("run command: %s timeout", strings.Join(cmdAndArgs, " "))
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to run command: %s | error: %v | stdout: %s | stderr: %s",
+			strings.Join(cmdAndArgs, " "), err, stdout.String(), stderr.String())
+	}
+
+	var stats cardStats
+	if err := json.Unmarshal(stdout.Bytes(), &stats); err != nil {
+		return nil, fmt.Errorf("failed to parse hy-smi JSON output: %v | stdout: %s", err, stdout.String())
+	}
+
+	return stats, nil
+}
+
+// fieldToMetric maps hy-smi field names to metric names and value multipliers.
+func fieldToMetric(field string) (string, float64) {
+	switch field {
+	case "Temperature (Sensor edge) (C)":
+		return "temperature_sensor_edge_celsius", 1
+	case "Temperature (Sensor junction) (C)":
+		return "temperature_sensor_junction_celsius", 1
+	case "Temperature (Sensor mem) (C)":
+		return "temperature_sensor_mem_celsius", 1
+	case "Temperature (Sensor core) (C)":
+		return "temperature_sensor_core_celsius", 1
+	case "HCU use (%)":
+		return "hcu_use_ratio", 0.01
+	case "HCU memory use (%)":
+		return "hcu_memory_use_ratio", 0.01
+	case "Voltage (mV)":
+		return "voltage_millivolts", 1
+	default:
+		return "", 0
+	}
+}

--- a/inputs/hy_smi/hy_smi.go
+++ b/inputs/hy_smi/hy_smi.go
@@ -86,7 +86,7 @@ func (s *HySMI) Gather(slist *types.SampleList) {
 
 		for fieldKey, rawValue := range fields {
 			// Skip string fields that are already used as info labels
-			if fieldKey == "Device ID" || fieldKey == "VBIOS version" {
+			if fieldKey == "Device ID" || fieldKey == "VBIOS version" || fieldKey == "Driver version" {
 				continue
 			}
 
@@ -115,6 +115,10 @@ func (s *HySMI) Gather(slist *types.SampleList) {
 
 func (s *HySMI) scrape() (cardStats, error) {
 	cmdAndArgs := strings.Fields(s.HySmiCommand)
+
+	if len(cmdAndArgs) == 0 {
+		return nil, fmt.Errorf("hy_smi_command is empty")
+	}
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer


### PR DESCRIPTION
新增 hy_smi 输入插件，通过执行 hy-smi 命令并解析其 JSON 输出来采集海光 GPU 监控指标。

变更内容：
- 新增 inputs/hy_smi/hy_smi.go：插件核心实现
- 新增 conf/input.hy_smi/hy_smi.toml：默认配置文件
- 新增 inputs/hy_smi/README.md：插件使用文档
- 在 agent/metrics_agent.go 中注册 hy_smi 插件

采集指标包括 GPU 温度（边缘/结点/显存/核心）、HCU 利用率、显存使用率、电压以及 GPU 信息标签。支持本地执行和远程SSH 执行两种方式，可配置采集超时时间。